### PR TITLE
Fixed bug in asset.py.

### DIFF
--- a/emspy/query/asset.py
+++ b/emspy/query/asset.py
@@ -67,7 +67,7 @@ class Asset(object):
 
 def size(an_asset):
 	
-	if issubclass(an_asset, Asset):
+	if not issubclass(an_asset, Asset):
 		raise TypeError("Input should be an object inherited from Asset class.")
 
 	if an_asset.list_all() is None: 


### PR DESCRIPTION
Changed one line in asset.py. In the size method, a TypeError is raised if the argument of size() **is** a subclass of Asset. The TypeError("Input should be an object inherited from Asset class.") should be raised if the argument **is NOT** a subclass of Asset.