### PR TITLE
Stuck in a fix for GE Mac OS machines that are having trouble creatin…

### DIFF
--- a/emspy/connection.py
+++ b/emspy/connection.py
@@ -160,8 +160,16 @@ class Connection(object):
 
 		# Normally you do NOT want to ignore SSL errors, but this is
 		# sometimes necessary on beta API endpoints without a proper cert.
-		return urllib.request.urlopen(req,
-							   context = ssl._create_unverified_context() if self.__ignore_ssl_errors else None)
+		# TODO: Find a real fix for GE Mac OS machines that are having trouble verifying.  
+		request = None
+		if self.__ignore_ssl_errors:
+			try:
+				request = urllib.request.urlopen(req, context=None)
+			except urllib.error.URLError:
+				request = urllib.request.urlopen(req, context=ssl._create_unverified_context())
+		else:
+			request = urllib.request.urlopen(req, context=None)
+		return request
 
 
 def print_resp(resp):


### PR DESCRIPTION
…g an SSL verified connection.  The flow is basically the same as before, with one added step.  As before, we only try an unverified context if the user sets 'ignore_ssl_errors=True' on the connection object.  By default, this is False and an unverified connection is not created.  If 'ignore_ssl_errors=True', we first try a verified connection.  If that does not succeed, we fall back on an unverified connection (as the name of the parameter implies).