### PR TITLE
Added networkx to setup.py requirements.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,6 @@ setup(name = 'emspy',
       author_email = 'jimin96@gmail.com',
       license = 'MIT',
       packages = find_packages(),
-      install_requires = ['numpy', 'pandas', 'future'],
+      install_requires = ['numpy', 'pandas', 'future', 'networkx'],
       zip_safe = False)
       


### PR DESCRIPTION
Added networkx to the setup.py requirements. 

Before doing this, emspy would install correctly, but wouldn't run.  Importing FltQuery from emspy.query would lead to an error due to networkx not existing in the local environment.  

To test this, I created a blank virtual environment, installed emspy using "pip install ." from the directory containing setup.py, and then ran a test script that simply imported FltQuery.  It failed as expected.  I then modified setup.py to include networkx and repeated the same process.  