### PR TITLE
Replace methods in patch with classes

### DIFF
--- a/tests/mock_ems.py
+++ b/tests/mock_ems.py
@@ -2,6 +2,10 @@ from __future__ import absolute_import
 
 
 class MockEMS(object):
+
+    def __init__(self, conn):
+        pass
+
     def update_list(self):
         pass
 

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -5,16 +5,6 @@ from unittest.mock import patch
 from mock_connection import MockConnection
 from mock_ems import MockEMS
 
-sys = 'ems24-app'
-
-user_name = ''
-pwd = ''
-proxies = {
-    'http': '',
-    'https': ''
-}
-
-c = MockConnection(user=user_name, pwd=pwd, proxies=proxies)
 
 # @patch() decorator replaces an object with a mock object for the test it decorates
 # For more information on how to use @patch, see https://stackoverflow.com/questions/32461465/python-patch-not-working
@@ -22,6 +12,8 @@ c = MockConnection(user=user_name, pwd=pwd, proxies=proxies)
 @patch('emspy.Connection', MockConnection)
 def test_excess_profile_matches_by_profile_name():
     try:
+        sys = 'ems24-app'
+        c = MockConnection(user='', pwd='')
         # There are multiple profiles with the exact name "Duplicate Profile" in the mocked data set.
         p = Profile(c, sys, profile_name='Duplicate Profile')
         assert False  # should never get here.
@@ -33,6 +25,8 @@ def test_excess_profile_matches_by_profile_name():
 @patch('emspy.Connection', MockConnection)
 def test_no_profile_matches_by_profile_name():
     try:
+        sys = 'ems24-app'
+        c = MockConnection(user='', pwd='')
         # Obviously a profile that would never exist.
         p = Profile(c, sys, profile_name='this profile would never exist 1 2 3 4')  # no profile should match.
         assert False  # should never get here.
@@ -44,6 +38,8 @@ def test_no_profile_matches_by_profile_name():
 @patch('emspy.Connection', MockConnection)
 def test_no_profile_matches_by_profile_number():
     try:
+        sys = 'ems24-app'
+        c = MockConnection(user='', pwd='')
         # Obviously a profile that would never exist.
         p = Profile(c, sys, profile_number=1000000000000000000000000000)  # no profile should match.
         assert False # should never get here.
@@ -54,6 +50,8 @@ def test_no_profile_matches_by_profile_number():
 @patch('emspy.query.query.EMS', MockEMS)
 @patch('emspy.Connection', MockConnection)
 def test_one_profile_match_by_profile_name():
+    sys = 'ems24-app'
+    c = MockConnection(user='', pwd='')
     p = Profile(c, sys, profile_name='Single Real Profile')  # no profile should match.
     assert (p._profile_name == 'Single Real Profile')
 
@@ -61,6 +59,8 @@ def test_one_profile_match_by_profile_name():
 @patch('emspy.query.query.EMS', MockEMS)
 @patch('emspy.Connection', MockConnection)
 def test_one_profile_match_by_profile_number():
+    sys = 'ems24-app'
+    c = MockConnection(user='', pwd='')
     p = Profile(c, sys, profile_number=108)  # one profile should match.
     assert (p._profile_name == 'Single Real Profile 2')
 
@@ -68,6 +68,8 @@ def test_one_profile_match_by_profile_number():
 @patch('emspy.query.query.EMS', MockEMS)
 @patch('emspy.Connection', MockConnection)
 def test_profile_attributes_by_profile_number():
+    sys = 'ems24-app'
+    c = MockConnection(user='', pwd='')
     p = Profile(c, sys, profile_number=88)  # one profile should match.
     assert (p._profile_name == 'Duplicate Profile')
     assert (p._guid == '5b8dc8cb-c8cb-c8cb-c8cb-c8cb39e6c8cb')
@@ -79,6 +81,8 @@ def test_profile_attributes_by_profile_number():
 @patch('emspy.query.query.EMS', MockEMS)
 @patch('emspy.Connection', MockConnection)
 def test_profile_attributes_by_profile_name():
+    sys = 'ems24-app'
+    c = MockConnection(user='', pwd='')
     p = Profile(c, sys, profile_name='Single Profile 3')  # one profile should match.
     assert (p._profile_name == 'Single Profile 3')
     assert (p._guid == 'f163eeee-63ee-63ee-63ee-1b363eed63ee')
@@ -91,6 +95,8 @@ def test_profile_attributes_by_profile_name():
 @patch('emspy.Connection', MockConnection)
 def test_bad_profile_name_search():
     try:
+        sys = 'ems24-app'
+        c = MockConnection(user='', pwd='')
         p = Profile(c, sys, profile_name='A PROFILE THAT SHOULD NEVER EXIST')  # no profiles should match.
         assert False
     except LookupError:

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -16,11 +16,10 @@ proxies = {
 
 c = MockConnection(user=user_name, pwd=pwd, proxies=proxies)
 
-
-@patch('emspy.query.ems.EMS.update_list', new=MockEMS.update_list)
-@patch('emspy.query.ems.EMS.get_id', new=MockEMS.get_id)
-@patch('emspy.Connection.request', new=MockConnection.request)
-
+# @patch() decorator replaces an object with a mock object for the test it decorates
+# For more information on how to use @patch, see https://stackoverflow.com/questions/32461465/python-patch-not-working
+@patch('emspy.query.query.EMS', MockEMS)
+@patch('emspy.Connection', MockConnection)
 def test_excess_profile_matches_by_profile_name():
     try:
         # There are multiple profiles with the exact name "Duplicate Profile" in the mocked data set.
@@ -30,9 +29,8 @@ def test_excess_profile_matches_by_profile_name():
         assert True
 
 
-@patch('emspy.query.ems.EMS.update_list', new=MockEMS.update_list)
-@patch('emspy.query.ems.EMS.get_id', new=MockEMS.get_id)
-@patch('emspy.Connection.request', new=MockConnection.request)
+@patch('emspy.query.query.EMS', MockEMS)
+@patch('emspy.Connection', MockConnection)
 def test_no_profile_matches_by_profile_name():
     try:
         # Obviously a profile that would never exist.
@@ -42,9 +40,8 @@ def test_no_profile_matches_by_profile_name():
         assert True
 
 
-@patch('emspy.query.ems.EMS.update_list', new=MockEMS.update_list)
-@patch('emspy.query.ems.EMS.get_id', new=MockEMS.get_id)
-@patch('emspy.Connection.request', new=MockConnection.request)
+@patch('emspy.query.query.EMS', MockEMS)
+@patch('emspy.Connection', MockConnection)
 def test_no_profile_matches_by_profile_number():
     try:
         # Obviously a profile that would never exist.
@@ -54,25 +51,22 @@ def test_no_profile_matches_by_profile_number():
         assert True
 
 
-@patch('emspy.query.ems.EMS.update_list', new=MockEMS.update_list)
-@patch('emspy.query.ems.EMS.get_id', new=MockEMS.get_id)
-@patch('emspy.Connection.request', new=MockConnection.request)
+@patch('emspy.query.query.EMS', MockEMS)
+@patch('emspy.Connection', MockConnection)
 def test_one_profile_match_by_profile_name():
     p = Profile(c, sys, profile_name='Single Real Profile')  # no profile should match.
     assert (p._profile_name == 'Single Real Profile')
 
 
-@patch('emspy.query.ems.EMS.update_list', new=MockEMS.update_list)
-@patch('emspy.query.ems.EMS.get_id', new=MockEMS.get_id)
-@patch('emspy.Connection.request', new=MockConnection.request)
+@patch('emspy.query.query.EMS', MockEMS)
+@patch('emspy.Connection', MockConnection)
 def test_one_profile_match_by_profile_number():
     p = Profile(c, sys, profile_number=108)  # one profile should match.
     assert (p._profile_name == 'Single Real Profile 2')
 
 
-@patch('emspy.query.ems.EMS.update_list', new=MockEMS.update_list)
-@patch('emspy.query.ems.EMS.get_id', new=MockEMS.get_id)
-@patch('emspy.Connection.request', new=MockConnection.request)
+@patch('emspy.query.query.EMS', MockEMS)
+@patch('emspy.Connection', MockConnection)
 def test_profile_attributes_by_profile_number():
     p = Profile(c, sys, profile_number=88)  # one profile should match.
     assert (p._profile_name == 'Duplicate Profile')
@@ -82,9 +76,8 @@ def test_profile_attributes_by_profile_number():
     assert (p._local_id == 88)
 
 
-@patch('emspy.query.ems.EMS.update_list', new=MockEMS.update_list)
-@patch('emspy.query.ems.EMS.get_id', new=MockEMS.get_id)
-@patch('emspy.Connection.request', new=MockConnection.request)
+@patch('emspy.query.query.EMS', MockEMS)
+@patch('emspy.Connection', MockConnection)
 def test_profile_attributes_by_profile_name():
     p = Profile(c, sys, profile_name='Single Profile 3')  # one profile should match.
     assert (p._profile_name == 'Single Profile 3')
@@ -94,13 +87,11 @@ def test_profile_attributes_by_profile_name():
     assert (p._local_id == 56)
 
 
-@patch('emspy.query.ems.EMS.update_list', new=MockEMS.update_list)
-@patch('emspy.query.ems.EMS.get_id', new=MockEMS.get_id)
-@patch('emspy.Connection.request', new=MockConnection.request)
+@patch('emspy.query.query.EMS', MockEMS)
+@patch('emspy.Connection', MockConnection)
 def test_bad_profile_name_search():
     try:
         p = Profile(c, sys, profile_name='A PROFILE THAT SHOULD NEVER EXIST')  # no profiles should match.
         assert False
     except LookupError:
         assert True
-


### PR DESCRIPTION
This branch fixes a namespace issue with the `@patch` decorator in the unit tests. By changing the module provided as the first argument to `@patch`, we can actually use classes which makes the tests a bit cleaner and easier to manage.

I also added a mock constructor to the `MockEMS` class because the tests raised ArgumentErrors when instantiating a new instance of the `EMS` class. I think these errors didn't come up before because replacing the methods used the actual `EMS` class constructor instead, bypassing the default `MockEMS` constructor via `@patch`.

Another thing I noticed was that the test suite passes even if I comment out the lines containing a `@patch` for `emspy.Connection`. Are these lines necessary? Maybe there's something going on under the hood that I'm not aware of.