### PR TITLE
replace deprecated argmin with idxmin

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/python
 
 pool:
-  vmImage: 'ubuntu-latest'
+  vmImage: 'windows-latest'
 strategy:
   matrix:
     Python27:

--- a/emspy/query/flight.py
+++ b/emspy/query/flight.py
@@ -444,7 +444,7 @@ class Flight(object):
 def get_shortest(fields):
     if isinstance(fields, pd.DataFrame) is False:
         sys.exit("Input should be a Pandas dataframe.")
-    return fields.loc[fields.name.str.len().argmin()].to_dict()
+    return fields.loc[fields.name.str.len().idxmin()].to_dict()
 
 
 def listdiff(a, b):

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,18 @@
+import sys
 from setuptools import setup, find_packages
 
 def readme():
     with open('README.md') as f:
         return f.read()
+    
+min_numpy_ver = "1.13.3"
+max_numpy_ver = ""
+if sys.version_info < (3, 0):
+    max_numpy_ver = "1.17"
+    
+numpy_install_rule = "numpy >= {numpy_ver}".format(numpy_ver=min_numpy_ver)
+if max_numpy_ver:
+    numpy_install_rule += ", < {numpy_ver}".format(numpy_ver=max_numpy_ver)
 
 setup(name = 'emspy',
       version = '0.2.4',
@@ -19,6 +29,6 @@ setup(name = 'emspy',
       author_email = 'AviationAdiSupport@ge.com',
       license = 'MIT',
       packages = find_packages(exclude=("docs","tests")),
-      install_requires = ['numpy', 'pandas==0.24.1', 'future', 'networkx'],
+      install_requires = [numpy_install_rule, 'pandas', 'future', 'networkx'],
       zip_safe = False)
       

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,15 @@ from setuptools import setup, find_packages
 def readme():
     with open('README.md') as f:
         return f.read()
-    
+
+# Numpy dropped support for python 2.7 in 1.17
+# Pandas dropped support for python 2.7 after 0.24.0
 min_numpy_ver = "1.13.3"
 max_numpy_ver = ""
+pandas_install_rule = 'pandas'
 if sys.version_info < (3, 0):
     max_numpy_ver = "1.17"
+    pandas_install_rule += "<=0.24.0"
     
 numpy_install_rule = "numpy >= {numpy_ver}".format(numpy_ver=min_numpy_ver)
 if max_numpy_ver:
@@ -29,6 +33,6 @@ setup(name = 'emspy',
       author_email = 'AviationAdiSupport@ge.com',
       license = 'MIT',
       packages = find_packages(exclude=("docs","tests")),
-      install_requires = [numpy_install_rule, 'pandas==0.24.0', 'future', 'networkx'],
+      install_requires = [numpy_install_rule, pandas_install_rule, 'future', 'networkx'],
       zip_safe = False)
       

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(name = 'emspy',
       author_email = 'AviationAdiSupport@ge.com',
       license = 'MIT',
       packages = find_packages(exclude=("docs","tests")),
-      install_requires = [numpy_install_rule, 'pandas', 'future', 'networkx'],
+      install_requires = [numpy_install_rule, 'pandas==0.24.1', 'future', 'networkx'],
       zip_safe = False)
       

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(name = 'emspy',
       author_email = 'AviationAdiSupport@ge.com',
       license = 'MIT',
       packages = find_packages(exclude=("docs","tests")),
-      install_requires = [numpy_install_rule, 'pandas==0.24.0', 'future', 'networkx'],
+      install_requires = [numpy_install_rule, 'pandas==0.23.4', 'future', 'networkx'],
       zip_safe = False)
       

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(name = 'emspy',
       author_email = 'AviationAdiSupport@ge.com',
       license = 'MIT',
       packages = find_packages(exclude=("docs","tests")),
-      install_requires = [numpy_install_rule, 'pandas==0.24.1', 'future', 'networkx'],
+      install_requires = [numpy_install_rule, 'pandas==0.24.0', 'future', 'networkx'],
       zip_safe = False)
       

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(name = 'emspy',
       author_email = 'AviationAdiSupport@ge.com',
       license = 'MIT',
       packages = find_packages(exclude=("docs","tests")),
-      install_requires = [numpy_install_rule, 'pandas==0.23.4', 'future', 'networkx'],
+      install_requires = [numpy_install_rule, 'pandas==0.24.0', 'future', 'networkx'],
       zip_safe = False)
       

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,6 @@ setup(name = 'emspy',
       author_email = 'jimin96@gmail.com',
       license = 'MIT',
       packages = find_packages(),
-      install_requires = ['numpy', 'pandas', 'future', 'networkx'],
+      install_requires = ['numpy', 'pandas==0.24.1', 'future', 'networkx'],
       zip_safe = False)
       

--- a/tests/test_flight.py
+++ b/tests/test_flight.py
@@ -1,0 +1,17 @@
+from emspy.query import flight
+
+import pandas as pd
+
+def test_get_shortest_field():
+    airframe_fields_dict = {
+        'ems_id': {29: 8, 30: 8},
+        'db_id': {29: '[ems-core][entity-type][foqa-flights]', 30: '[ems-core][entity-type][foqa-flights]'},
+        'id': {29: '[-hub-][field][[[ems-core][entity-type][foqa-flights]][[airframe-engine-field-set][base-field][airframe]]]', 30: '[-hub-][field][[[ems-core][entity-type][foqa-flights]][[airframe-engine-field-set][base-field][airframe-engine-series]]]'},
+        'nodetype': {29: 'field', 30: 'field'},
+        'type': {29: 'discrete', 30: 'discrete'},
+        'name': {29: 'Airframe', 30: 'Airframe Engine Series'},
+        'parent_id': {29: '[-hub-][field-group][[[ems-core][entity-type][foqa-flights]][[ems-core][internal-field-group][aircraft-info]]]', 30: '[-hub-][field-group][[[ems-core][entity-type][foqa-flights]][[ems-core][internal-field-group][aircraft-info]]]'}}
+    airframe_fields_dataframe = pd.DataFrame.from_dict(airframe_fields_dict)
+    airframe_field = flight.get_shortest(airframe_fields_dataframe)
+    assert(airframe_field['name'] == "Airframe")
+    


### PR DESCRIPTION
In the get shortest field function it was using argmin which is deprecated and has recently changed behavior.  The new behavior is causing keylookup errors.  Switching to idxmin should fix this.