### PR TITLE
Use tz_convert to avoid issues with tz_localize

### DIFF
--- a/emspy/query/fltquery.py
+++ b/emspy/query/fltquery.py
@@ -557,7 +557,7 @@ class FltQuery(Query):
                 elif ctype == 'boolean':
                     df.iloc[:, i] = df.iloc[:, i].astype(bool)
                 elif ctype == 'dateTime':
-                    df.iloc[:, i] = pd.to_datetime(df.iloc[:, i]).dt.tz_convert('UTC')
+                    df.iloc[:, i] = pd.to_datetime(df.iloc[:, i], utc=True)
             except ValueError:
                 print("Somethings wrong when converting to Pandas DataFrame for column '%s' "
                       "(type: %s)." % (cname, ctype))

--- a/emspy/query/fltquery.py
+++ b/emspy/query/fltquery.py
@@ -557,7 +557,7 @@ class FltQuery(Query):
                 elif ctype == 'boolean':
                     df.iloc[:, i] = df.iloc[:, i].astype(bool)
                 elif ctype == 'dateTime':
-                    df.iloc[:, i] = pd.to_datetime(df.iloc[:, i]).dt.tz_localize('UTC')
+                    df.iloc[:, i] = pd.to_datetime(df.iloc[:, i]).dt.tz_convert('UTC')
             except ValueError:
                 print("Somethings wrong when converting to Pandas DataFrame for column '%s' "
                       "(type: %s)." % (cname, ctype))


### PR DESCRIPTION
See #59 - tz_localize isn't happy in some instances where the inherited dataframe has already decided it's a tz-aware column:

https://stackoverflow.com/questions/48034875/typeerror-already-tz-aware-use-tz-convert-to-convert-when-i-update-pandas

I'm not sure tz_convert is actually the intended behaviour here, but it seems closer to the intent.