### PR TITLE
Fltquery from json

### DIFF
--- a/emspy/query/fltquery.py
+++ b/emspy/query/fltquery.py
@@ -380,7 +380,7 @@ class FltQuery(Query):
         """
 
         if type(json_str) is not str:
-            raise Type(f'json_str should be a str. Found: {type(json_str)}')
+            raise TypeError('json_str should be a str. Found: {0}'.format(type(json_str)))
 
         self.__queryset = json.loads(json_str)
 

--- a/emspy/query/fltquery.py
+++ b/emspy/query/fltquery.py
@@ -369,6 +369,21 @@ class FltQuery(Query):
     #         y = "none"
     #     self.__queryset['format'] = y
 
+    def from_json_string(self, json_str):
+        """
+        Load the JSON string for this query.
+
+        Parameters
+        ----------
+        json_str: str
+            Queryset as a JSON str.
+        """
+
+        if type(json_str) is not str:
+            raise Type(f'json_str should be a str. Found: {type(json_str)}')
+
+        self.__queryset = json.loads(json_str)
+
     def in_json(self):
         """
         Dump the queryset as JSON


### PR DESCRIPTION
I added a `from_json_string(self, json_str)` method to the `FltQuery` class. It accepts a string that can be loaded using `json.loads(json_str)`. The string is then set as the class `queryset`. 

The reason I chose to accept a string argument rather than a dict, for example, is that this same class's `in_json()` method returns a string that is dumped via `json.dumps(self.__queryset)`. Therefore, also loading a string is more self-consistent. 