### PR TITLE
Analytic sets

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.1
+current_version = 0.6.0
 commit = True
 tag = True
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__
 .vscode
 test-output.xml
 test.db
+tmpDB.db

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ tsq.select(
 ```
 
 ### Loading Analytics from a Parameter Set
-If you want to load all Analytics from a paramerter set, you can use the `select_from_pset()` method. This will load ALL parametes in the set in the same order that they are in the EMS parameter set. This method requires one input: the path to the parameter set, including the name of the set itself. Folders in the path need to be separated usuing a backslash ("\\"). To find the path to the parameter set, look at the "Load" menu in FDV+
+If you want to load all Analytics from a parameters set, you can use the `select_from_pset()` method. This will load ALL parametes in the set in the same order that they are in the EMS parameter set. This method requires one input: the path to the parameter set, including the name of the set itself. Folders in the path need to be separated usuing a backslash ("\\"). To find the path to the parameter set, look at the "Load" menu in FDV+
 
 ```python
 tsq.select_from_pset('folder1\folder2\set name')
@@ -421,7 +421,7 @@ Make sure you import the AnalyticSet class like this
 ```python
 from emspy.query import AnalyticSet
 ```
-Next, instantiate a analytic_set bobject using a connection (c) and a system_is (1)
+Next, instantiate an analytic_set object using a connection (c) and a system_id (1)
 ```python
 from emspy.query import AnalyticSet
 analytic_set = AnalyticSet(c,1)
@@ -431,7 +431,7 @@ Finally use the `get_analytic_set()` method to get info for the set of interest.
 analytic_set_df = analytic_set.get_analytic_set('folder1\folder2\set name')
 ```
 
-If you want to know what folders and sets are inside a folder, you can use the `get_group_content()` method. This takes just the path to the folder yuu are interested in as the only input.
+If you want to know what folders and sets are inside a folder, you can use the `get_group_content()` method. This takes just the path to the folder you are interested in as the only input.
 To search the root folder, do not pass an input or use an empty string ("")
 ```python
 analytic_set.get_group_content("folder1\folder2")

--- a/README.md
+++ b/README.md
@@ -365,7 +365,17 @@ tsq.select(
   force_search=True)
 ```
 
-### Querying Analytics
+### Loading Analytics from a Parameter Set
+If you want to load all Analytics from a paramerter set, you can use the `select_from_pset()` method. This will load ALL parametes in the set in the same order that they are in the EMS parameter set. This method requires one input: the path to the parameter set, including the name of the set itself. Folders in the path need to be separated usuing a backslash ("\\"). To find the path to the parameter set, look at the "Load" menu in FDV+
+
+```python
+tsq.select_from_pset('folder1\folder2\set name')
+```
+
+Note: this method acts similarly to the `select()` method, so it will add to the existing list of selected parameters.
+Note: this method will not search the EMS systems for parameters, so it will not add these to the local cache for later searching.
+
+## Querying Analytics
 
 You can retrieve a list of physical parameters for a flight by utilizing methods in the Analytic class. 
 
@@ -404,3 +414,26 @@ metadata = analytic_query.get_flight_analytic_metadata(analytic_id=analytic_id, 
     'Parameter\\Name': Foo
 }
 ```
+
+## Querying Parameter Sets (Analytic Sets)
+You can retrieve information for parameter sets (called analytic sets in the API routes) using the `AnlyticSet` class.
+Make sure you import the AnalyticSet class like this
+```python
+from emspy.query import AnalyticSet
+```
+Next, instantiate a analytic_set bobject using a connection (c) and a system_is (1)
+```python
+from emspy.query import AnalyticSet
+analytic_set = AnalyticSet(c,1)
+```
+Finally use the `get_analytic_set()` method to get info for the set of interest. This method requires one input: the path to the parameter set, including the name of the set itself. Folders in the path need to be separated usuing a backslash ("\\"). To find the path to the parameter set, look at the "Load" menu in FDV+
+```python
+analytic_set_df = analytic_set.get_analytic_set('folder1\folder2\set name')
+```
+
+If you want to know what folders and sets are inside a folder, you can use the `get_group_content()` method. This takes just the path to the folder yuu are interested in as the only input.
+To search the root folder, do not pass an input or use an empty string ("")
+```python
+analytic_set.get_group_content("folder1\folder2")
+```
+This method returns a dictionary with two keys: 'groups' and 'sets'. groups will have info about the folders, while sets will have info about parameter sets.

--- a/emspy/__init__.py
+++ b/emspy/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from .connection import Connection 
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"

--- a/emspy/query/__init__.py
+++ b/emspy/query/__init__.py
@@ -10,4 +10,5 @@ from emspy.query.fltquery import FltQuery
 from emspy.query.tsquery import TSeriesQuery
 from emspy.query.profile import Profile
 from emspy.query.dbmodify import InsertQuery
+from emspy.query.analyticset import AnalyticSet
 

--- a/emspy/query/analyticset.py
+++ b/emspy/query/analyticset.py
@@ -2,18 +2,23 @@ from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
 
-import re
-import urllib.error
 from .asset import Asset
 import pandas as pd
 
 
 class AnalyticSet(Asset):
+    # Declaring static variable for the possible colimns in an analytic set
+    analytic_set_columns = ['id', 'name', 'description',
+        'units', 'metadata','chartIndex', 'chartSize', 
+        'customName', 'color', 'customRange', 'customDigitsAfterDecimal', 
+        'lineWidth', 'displaySampleMarker', 'sampleMarkerShape', 
+        'lineStyle', 'parameterFilteringMode', 'interpolationMode'
+    ]
     """
     Manages analytic sets querying
     """
 
-    def __init__(self, conn, ems_id, exclude_trees=[], exclude_patterns=[]):
+    def __init__(self, conn, ems_id):
         """
         Analytics set asset object initialization
 
@@ -23,33 +28,27 @@ class AnalyticSet(Asset):
             connection object
         ems_id: int
             EMS system id
-        exclude_trees: list
-            list of trees to exclude from the group update, such as:
-            "Engine Services", "ADI", "EMS Library"
-        exclude_patterns: list
-            list of regex patterns for exclusion of groups, such as:
-            r"Engine Services:\d{9}.*" to exclude all SSO subdirectories in Engine Services
         """
         Asset.__init__(self, conn, "AnalyticSet")
         self._ems_id = ems_id
         self._analytic_set = {}
-        self._analytic_sets = []
-        self._analytics = []
-        self.exclude_trees = exclude_trees
-        self.exclude_patterns = exclude_patterns
-        if len(self.exclude_patterns) > 0:
-            self.exclude_patterns = [re.compile(pattern) for pattern in self.exclude_patterns]
-        #self.update_list()
 
-    def __parse_analytic_set(self):
-        analytics = self._analytic_set['items']
-        for idx, analytic in enumerate(analytics):
-            for key, value in analytic['analytic'].items():
-                analytics[idx][key] = value
-            del analytics[idx]['analytic']
-        return analytics
 
     def get_analytic_set(self, analytic_set_name, group_path=['root']):
+        """
+        Gets analytic set analytic_set_name in the folder defined in the group_path
+
+        Parameters
+        ----------
+        analytics_set_name: str
+            set name
+        group_path: list of str
+            the path (folders) to the location of the analytic set
+
+        Returns
+        -------
+        None
+        """
         if len(group_path) == 0:
             group_path=['root']
         if (len(group_path) == 1) and ((group_path[0].lower() == 'root') or (group_path[0].lower() == 'parameter sets')):
@@ -59,109 +58,82 @@ class AnalyticSet(Asset):
                 del group_path[0]
             group_id = ":".join(group_path)
         
-        _, dict_data = self._conn.request(
-            uri_keys=('analyticSet', 'analytic_set'),
-            uri_args=(self._ems_id, group_id, analytic_set_name)
-        )
-        self._analytic_set = dict_data
-
-        list_of_entries = self.__parse_analytic_set()
-        data_df = pd.DataFrame.from_records(list_of_entries)
-
-        analytics_df = pd.DataFrame(columns=['id', 'name', 'description', 'units', 'metadata','chartIndex', 'chartSize', 'customName', 'color', 'customRange', 'customDigitsAfterDecimal', 'lineWidth', 'displaySampleMarker', 'sampleMarkerShape', 'lineStyle', 'parameterFilteringMode', 'interpolationMode'])
-
-        analytics_df = pd.concat([data_df,analytics_df])
-        return analytics_df
-
-
-    def __get_analytic_set_group(self, groupId, recurse=True):
-        if groupId in self.exclude_trees:
-            print('-- Excluding analytic set group {0}'.format(groupId))
-            return
-        for pattern in self.exclude_patterns:
-            if re.match(pattern, groupId) is not None:
-                print('-- Excluding analytic set group {0}'.format(groupId))
-                return
+        folder_path = "\\".join(group_path)
+        print(f'-- Fetching analytic set "{analytic_set_name}" in folder {folder_path}')
         try:
-            print('-- Fetching analytic set group {0}'.format(groupId))
             _, dict_data = self._conn.request(
-                uri_keys=('analyticSet', 'analytic_set_group'),
-                uri_args=(self._ems_id, groupId)
+                uri_keys=('analyticSet', 'analytic_set'),
+                uri_args=(self._ems_id, group_id, analytic_set_name)
             )
-            self._analytic_sets.append(dict_data)
-            if recurse:
-                for group in dict_data['groups']:
-                    self.__get_analytic_set_group(group['groupId'])
-    
-        except urllib.error.HTTPError:
-            print('-- Failed to fetch analytic set group {0}'.format(groupId))
+            self._analytic_set = dict_data
 
-    def update_list(self):
-        """
-        Update analytic sets list
+            list_of_entries = self.__parse_analytic_set()
+            data_df = pd.DataFrame.from_records(list_of_entries)
 
-        Returns
-        -------
-        None
-        """
-        self.__get_analytic_set_group('Root', recurse=False)
-        self._analytic_sets = pd.DataFrame(self._analytic_sets)
-        self._analytic_sets = self._analytic_sets.drop(['groups', 'sets'], axis=1)\
-            .join(self._analytic_sets['sets'].apply(pd.Series))\
-            .melt(id_vars=['name', 'groupId'], value_name='set')\
-            .drop('variable', axis=1)\
-            .dropna(subset=['set'])
-        self._analytic_sets['set'] = self._analytic_sets['set'].apply(lambda d: d['name'])
-        self._analytic_sets.sort_values(['name', 'groupId', 'set'], inplace=True)
-        self._analytic_sets.reset_index(drop=True, inplace=True)
+            analytics_df = pd.DataFrame(columns=AnalyticSet.analytic_set_columns)
 
-    def select_set(self, analytics_set_name=None, searchtype='match'):
+            analytics_df = pd.concat([data_df,analytics_df])
+            return analytics_df
+        except:
+            print('-- Failed to fetch analytic set "{analytic_set_name}" in folder{folder_path}')
+
+
+    def get_group_content(self, group_path=['root']):
         """
-        Get fleet name from id
+        Returns the group names/ids and analytic names that are contained in the folder
+        defined by the group_path list. 
 
         Parameters
         ----------
-        analytics_set_name: str
-            set name
-        searchtype: str
-            search type:
-                contains: inexact matching (returns shortest)
-                match: exact matching
+        group_path: list of str
+            the path (folders) to the location of the analytic set
 
         Returns
         -------
-        None
+        Dict with two elements: groups and sets. Both of these are Dataframes
         """
-        analytics_set = self.search('set', analytics_set_name, searchtype)
-        if analytics_set.shape[0] > 1:
-            analytics_set = analytics_set.loc[analytics_set['set'].str.len().idxmin(), :]\
-                .to_frame().T
+        # Dictinary that will contain the results
+        group_dict = {}
+        if len(group_path) == 0:
+            group_path=['root']
+        if (len(group_path) == 1) and ((group_path[0].lower() == 'root') or (group_path[0].lower() == 'parameter sets')):
+            group_id = 'root'
+        else:
+            if (group_path[0].lower() == 'root') or (group_path[0].lower() == 'parameter sets'):
+                del group_path[0]
+            group_id = ":".join(group_path)
+        group_info = self.__get_analytic_set_group(group_id)
+        
+        if len(group_info['groups']) > 0:
+            groups_df = pd.DataFrame.from_records(group_info['groups'])
+            group_dict['groups'] = groups_df
+        else:
+            group_dict['groups'] = pd.DataFrame()
+        
+        if len(group_info['sets']) > 0:
+            sets_df = pd.DataFrame.from_records(group_info['sets'])
+            group_dict['sets'] = sets_df
+        else:
+            group_dict['sets'] = pd.DataFrame()
+        
+        return group_dict
+
+    
+    def __get_analytic_set_group(self, groupId):
+        print(f'-- Fetching info for analytic set group {groupId}')
         _, dict_data = self._conn.request(
-            uri_keys=('analyticSet', 'analytic_set'),
-            uri_args=(self._ems_id, analytics_set.iloc[0]['groupId'], analytics_set.iloc[0]['set'])
+            uri_keys=('analyticSet', 'analytic_set_group'),
+            uri_args=(self._ems_id, groupId)
         )
-        self._analytics = pd.DataFrame(dict_data)
-        self._analytics = self._analytics.drop('items', axis=1) \
-            .join(self._analytics['items'].apply(pd.Series))
-        self._analytics = self._analytics.drop('analytic', axis=1) \
-            .join(self._analytics['analytic'].apply(pd.Series), rsuffix='_analytic')
-        return self._analytics
-
-    def list_all(self):
-        return self._analytics
-
-    def _rename_datacol(self, old, new):
-        # Rename a column
-        raise NotImplementedError
-
-    def data_colnames(self):
+        return dict_data
+    
+    def __parse_analytic_set(self):
         """
-        Returns the columns for the asset dataframe
-
-        Returns
-        -------
-        pd.Index
-            dataframe columns
+        Parses an analytic set into a list of flattened dictionaries. Essentially moved the 'analytic' boject items up one level in each analytic
         """
-        return self._analytics.columns
-
+        analytics = self._analytic_set['items']
+        for idx, analytic in enumerate(analytics):
+            for key, value in analytic['analytic'].items():
+                analytics[idx][key] = value
+            del analytics[idx]['analytic']
+        return analytics

--- a/emspy/query/analyticset.py
+++ b/emspy/query/analyticset.py
@@ -71,8 +71,10 @@ class AnalyticSet(Asset):
             # Remove empty items from list
             path_list = [i for i in path_list if i]
 
-            if (path_list[0].lower() == 'parameter sets') or (path_list[0].lower() == 'root'):
-                path_list.pop(0)
+            # In case the path starts with "root" or "parameter sets"
+            if len(path_list) > 0:
+                if (path_list[0].lower() == 'parameter sets') or (path_list[0].lower() == 'root'):
+                    path_list.pop(0)
 
             if len(path_list) == 0:
                 self._group_id = 'root'
@@ -93,8 +95,9 @@ class AnalyticSet(Asset):
         -------
         DataFrame
         """
+ 
         if not analytic_set_path:
-            raise ValueError("No Analytic Set path was passed in")
+            raise ValueError('No Analytic Set path was passed in. To access the root folder use "\<set name>" or "root\<set name>"')
         self._analytic_set_path = analytic_set_path
         self.__parse_path()
         
@@ -112,7 +115,7 @@ class AnalyticSet(Asset):
 
             analytic_set_df = pd.DataFrame(columns=AnalyticSet.__analytic_set_columns)
 
-            analytic_set_df = pd.concat([data_df, analytic_set_df])
+            analytic_set_df = pd.concat([analytic_set_df, data_df])
             return analytic_set_df
         except:
             print(f'-- Failed to fetch analytic set "{self._analytic_set_path}"')

--- a/emspy/query/analyticset.py
+++ b/emspy/query/analyticset.py
@@ -101,7 +101,7 @@ class AnalyticSet(Asset):
         self._analytic_set_path = analytic_set_path
         self.__parse_path()
         
-        print(f'-- Fetching analytic set "{self._analytic_set_path}"')
+        print('-- Fetching analytic set "%s"' % self._analytic_set_path)
         try:
             _, dict_data = self._conn.request(
                 uri_keys=('analyticSet', 'analytic_set'),
@@ -118,7 +118,7 @@ class AnalyticSet(Asset):
             analytic_set_df = pd.concat([analytic_set_df, data_df])
             return analytic_set_df
         except:
-            print(f'-- Failed to fetch analytic set "{self._analytic_set_path}"')
+            print('-- Failed to fetch analytic set "%s"' % self._analytic_set_path)
 
 
     def get_group_content(self, analytic_group_path=None):
@@ -162,7 +162,7 @@ class AnalyticSet(Asset):
         
     
     def __get_analytic_set_group(self):
-        print(f'-- Fetching info for analytic set group {self._group_id}')
+        print('-- Fetching info for analytic set group %s' % self._group_id)
         _, dict_data = self._conn.request(
             uri_keys=('analyticSet', 'analytic_set_group'),
             uri_args=(self._ems_id, self._group_id)

--- a/emspy/query/analyticset.py
+++ b/emspy/query/analyticset.py
@@ -4,6 +4,7 @@ standard_library.install_aliases()
 
 from .asset import Asset
 import pandas as pd
+import re
 
 
 class AnalyticSet(Asset):
@@ -59,7 +60,8 @@ class AnalyticSet(Asset):
             for key,value in ref_dict.items():
                 self._analytic_set_path = self._analytic_set_path.replace(key, value)
 
-            path_list = self._analytic_set_path.split('\\')
+            # Split on both \ and /
+            path_list = re.split(r'[\\,/]', self._analytic_set_path)
             if not path_only:
                 self._analytic_set_id = path_list.pop()
                 # In case the path ended with "\"
@@ -80,7 +82,7 @@ class AnalyticSet(Asset):
 
     def get_analytic_set(self, analytic_set_path):
         """
-        Gets analytic the data for the analytic set in the analytic_set_path
+        Retrieves the data for the analytic set in the analytic_set_path
 
         Parameters
         ----------
@@ -110,7 +112,7 @@ class AnalyticSet(Asset):
 
             analytic_set_df = pd.DataFrame(columns=AnalyticSet.__analytic_set_columns)
 
-            analytic_set_df = pd.concat([data_df,analytic_set_df])
+            analytic_set_df = pd.concat([data_df, analytic_set_df])
             return analytic_set_df
         except:
             print(f'-- Failed to fetch analytic set "{self._analytic_set_path}"')

--- a/emspy/query/analyticset.py
+++ b/emspy/query/analyticset.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 class AnalyticSet(Asset):
     # Declaring static variable for the possible colimns in an analytic set
-    analytic_set_columns = ['id', 'name', 'description',
+    __analytic_set_columns = ['id', 'name', 'description',
         'units', 'metadata','chartIndex', 'chartSize', 
         'customName', 'color', 'customRange', 'customDigitsAfterDecimal', 
         'lineWidth', 'displaySampleMarker', 'sampleMarkerShape', 
@@ -18,7 +18,7 @@ class AnalyticSet(Asset):
     Manages analytic sets querying
     """
 
-    def __init__(self, conn, ems_id):
+    def __init__(self, conn, ems_id, analytic_set_path=None):
         """
         Analytics set asset object initialization
 
@@ -28,57 +28,95 @@ class AnalyticSet(Asset):
             connection object
         ems_id: int
             EMS system id
+        analytic_set_path: str
+            The path to the analytic set
         """
         Asset.__init__(self, conn, "AnalyticSet")
         self._ems_id = ems_id
-        self._analytic_set = {}
+        self._analytic_set_path = analytic_set_path
+        self.__parse_path()
 
+    def __parse_path(self, path_only=False):
+        if not self._analytic_set_path:
+            self._group_id = None
+            self._analytic_set_id = None
+            self._analytic_set_name = None
+            self._analytic_set_description = None
+            return
+        else:
+            # Apparently there is no easy why to escape all "\" special characters in python
+            # So have to do a find replace first
+            ref_dict = {
+                '\x07':'\\a',
+                '\x08':'\\b',
+                '\x0C':'\\f',
+                '\n':'\\n',
+                '\r':'\\r',
+                '\t':'\\t',
+                '\x0b':'\\v',                
+            }
+            # First we need to replace all special backslash characters
+            for key,value in ref_dict.items():
+                self._analytic_set_path = self._analytic_set_path.replace(key, value)
 
-    def get_analytic_set(self, analytic_set_name, group_path=['root']):
+            path_list = self._analytic_set_path.split('\\')
+            if not path_only:
+                self._analytic_set_id = path_list.pop()
+                # In case the path ended with "\"
+                if self._analytic_set_id == '':
+                    raise ValueError('Missing analytic set name. It should be at the end of the path')
+            
+            # Remove empty items from list
+            path_list = [i for i in path_list if i]
+
+            if (path_list[0].lower() == 'parameter sets') or (path_list[0].lower() == 'root'):
+                path_list.pop(0)
+
+            if len(path_list) == 0:
+                self._group_id = 'root'
+            else:
+                # The group_id is just the folder path separated by ":"
+                self._group_id = ":".join(path_list)
+
+    def get_analytic_set(self, analytic_set_path):
         """
-        Gets analytic set analytic_set_name in the folder defined in the group_path
+        Gets analytic the data for the analytic set in the analytic_set_path
 
         Parameters
         ----------
-        analytics_set_name: str
-            set name
-        group_path: list of str
-            the path (folders) to the location of the analytic set
+        analytic_set_path: str
+            The path (from root using "\" as separator) to the analytic set
 
         Returns
         -------
-        None
+        DataFrame
         """
-        if len(group_path) == 0:
-            group_path=['root']
-        if (len(group_path) == 1) and ((group_path[0].lower() == 'root') or (group_path[0].lower() == 'parameter sets')):
-            group_id = 'root'
-        else:
-            if (group_path[0].lower() == 'root') or (group_path[0].lower() == 'parameter sets'):
-                del group_path[0]
-            group_id = ":".join(group_path)
+        if not analytic_set_path:
+            raise ValueError("No Analytic Set path was passed in")
+        self._analytic_set_path = analytic_set_path
+        self.__parse_path()
         
-        folder_path = "\\".join(group_path)
-        print(f'-- Fetching analytic set "{analytic_set_name}" in folder {folder_path}')
+        print(f'-- Fetching analytic set "{self._analytic_set_path}"')
         try:
             _, dict_data = self._conn.request(
                 uri_keys=('analyticSet', 'analytic_set'),
-                uri_args=(self._ems_id, group_id, analytic_set_name)
+                uri_args=(self._ems_id, self._group_id, self._analytic_set_id)
             )
-            self._analytic_set = dict_data
 
-            list_of_entries = self.__parse_analytic_set()
-            data_df = pd.DataFrame.from_records(list_of_entries)
+            flat_analytic_set_dict = self.__parse_analytic_set(dict_data)
+            self._analytic_set_name = flat_analytic_set_dict['name']
+            self._analytic_set_description = flat_analytic_set_dict['description']
+            data_df = pd.DataFrame.from_records(flat_analytic_set_dict['items'])
 
-            analytics_df = pd.DataFrame(columns=AnalyticSet.analytic_set_columns)
+            analytic_set_df = pd.DataFrame(columns=AnalyticSet.__analytic_set_columns)
 
-            analytics_df = pd.concat([data_df,analytics_df])
-            return analytics_df
+            analytic_set_df = pd.concat([data_df,analytic_set_df])
+            return analytic_set_df
         except:
-            print('-- Failed to fetch analytic set "{analytic_set_name}" in folder{folder_path}')
+            print(f'-- Failed to fetch analytic set "{self._analytic_set_path}"')
 
 
-    def get_group_content(self, group_path=['root']):
+    def get_group_content(self, analytic_group_path=None):
         """
         Returns the group names/ids and analytic names that are contained in the folder
         defined by the group_path list. 
@@ -94,15 +132,13 @@ class AnalyticSet(Asset):
         """
         # Dictinary that will contain the results
         group_dict = {}
-        if len(group_path) == 0:
-            group_path=['root']
-        if (len(group_path) == 1) and ((group_path[0].lower() == 'root') or (group_path[0].lower() == 'parameter sets')):
-            group_id = 'root'
-        else:
-            if (group_path[0].lower() == 'root') or (group_path[0].lower() == 'parameter sets'):
-                del group_path[0]
-            group_id = ":".join(group_path)
-        group_info = self.__get_analytic_set_group(group_id)
+        
+        if not analytic_group_path:
+            analytic_group_path = 'root'
+        self._analytic_set_path = analytic_group_path
+        self.__parse_path(path_only=True)
+
+        group_info = self.__get_analytic_set_group()
         
         if len(group_info['groups']) > 0:
             groups_df = pd.DataFrame.from_records(group_info['groups'])
@@ -118,22 +154,24 @@ class AnalyticSet(Asset):
         
         return group_dict
 
+        
     
-    def __get_analytic_set_group(self, groupId):
-        print(f'-- Fetching info for analytic set group {groupId}')
+    def __get_analytic_set_group(self):
+        print(f'-- Fetching info for analytic set group {self._group_id}')
         _, dict_data = self._conn.request(
             uri_keys=('analyticSet', 'analytic_set_group'),
-            uri_args=(self._ems_id, groupId)
+            uri_args=(self._ems_id, self._group_id)
         )
         return dict_data
     
-    def __parse_analytic_set(self):
+    
+    def __parse_analytic_set(self, base_analytic_dict):
         """
         Parses an analytic set into a list of flattened dictionaries. Essentially moved the 'analytic' boject items up one level in each analytic
         """
-        analytics = self._analytic_set['items']
+        analytics = base_analytic_dict['items']
         for idx, analytic in enumerate(analytics):
             for key, value in analytic['analytic'].items():
                 analytics[idx][key] = value
             del analytics[idx]['analytic']
-        return analytics
+        return base_analytic_dict

--- a/emspy/query/tsquery.py
+++ b/emspy/query/tsquery.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from emspy.query import *
 from .query import Query
-
+from .analyticset import AnalyticSet
 
 class TSeriesQuery(Query):
     """
@@ -222,6 +222,32 @@ class TSeriesQuery(Query):
             self.__columns.append(prm)
         if save_table:
             self.__analytic._save_paramtable()
+
+    def select_from_pset(self, analytic_set_path):
+        """
+        A method for selecting parameters to query from a parameter set
+
+        Parameters
+        ----------
+        analytics_set_name: str
+            set name
+        group_path: list of str
+            the path (folders) to the location of the analytic set
+
+        Returns
+        -------
+        None
+        """
+        # Get the Analytics from the parameter set  using the get_analytic_set() method
+        # from the AnalyticSet Class
+        pset = AnalyticSet(self._conn, self._ems_id)
+        pset_df = pset.get_analytic_set(analytic_set_path)
+        for analytic in pset_df.to_dict(orient='records'):
+            # Adding analytic ids to the query body
+            self.__queryset['select'].append({'analyticId': analytic['id']})
+            # Adding to the columns for iteration over the results
+            self.__columns.append(analytic)
+        
 
     def range(self, start=None, end=None):
         """

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if max_numpy_ver:
     numpy_install_rule += ", < {numpy_ver}".format(numpy_ver=max_numpy_ver)
 
 setup(name = 'emspy',
-      version = '0.5.1',
+      version = '0.6.0',
       description = 'A Python EMS RESTful API Client/Wrapper',
       long_description=readme(),
       long_description_content_type="text/markdown",

--- a/tests/mock_connection.py
+++ b/tests/mock_connection.py
@@ -405,7 +405,7 @@ class MockConnection(Connection):
             if analytic_set_id == 'A PARAMETER SET THAT DOES NOT EXIST':
                 content = {
                     "message": "Invalid Analytic Set",
-                    "messageDetail": f"Unable to find an analytic set with the name {analytic_set_id} in group {group_id}",
+                    "messageDetail": "Unable to find an analytic set with the name {analytic_set_id} in group {group_id}".format(analytic_set_id=analytic_set_id, group_id=group_id),
                     "unexpected": False
                 }
             else:
@@ -487,14 +487,14 @@ class MockConnection(Connection):
                     "groups": [
                         {
                             "name": "Mock Folder 1",
-                            "groupId": f"{group_id}:Mock Folder 1",
+                            "groupId": "{}:Mock Folder 1".format(group_id),
                             "groups": [],
                             "sets": [],
                             "collections": []
                         },
                         {
                             "name": "Mock Folder 2",
-                            "groupId": f"{group_id}:Mock Folder 2",
+                            "groupId": "{}:Mock Folder 2".format(group_id),
                             "groups": [],
                             "sets": [],
                             "collections": []

--- a/tests/mock_connection.py
+++ b/tests/mock_connection.py
@@ -19,6 +19,7 @@ class MockConnection(Connection):
     """
     Object for connection to EMS API
     """
+
     def __init__(self, user, pwd):
         super(MockConnection, self).__init__(user=user, pwd=pwd)
 
@@ -399,6 +400,118 @@ class MockConnection(Connection):
                     'description': 'N) Parking'
                 }
             ]
+        elif uri_keys == ('analyticSet', 'analytic_set'):
+            ems_id, group_id, analytic_set_id = uri_args
+            if analytic_set_id == 'A PARAMETER SET THAT DOES NOT EXIST':
+                content = {
+                    "message": "Invalid Analytic Set",
+                    "messageDetail": f"Unable to find an analytic set with the name {analytic_set_id} in group {group_id}",
+                    "unexpected": False
+                }
+            else:
+                content = {
+                    "name": analytic_set_id,
+                    "description": "mock parameter set description",
+                    "items": [
+                        {
+                            "chartIndex": 0,
+                            "analytic": {
+                                "id": "fake-pres-alt-id-that-exists=",
+                                "name": "Pressure Altitude (ft)",
+                                "description": "Altitude derived from static air pressure.  A value of zero should always correspond to static air pressure = 29.92 inches of mercury.",
+                                "units": "ft",
+                                "metadata": None
+                            },
+                            "color": "#000000"
+                        },
+                        {
+                            "chartIndex": 1,
+                            "analytic": {
+                                "id": "fake-rad-alt-id-that-exists=",
+                                "name": "Radio Altitude (1, left, Capt or Only) (ft)",
+                                "description": "This is the recorded radio altitude value (in feet) of the 'primary' radio altimeter.  Preferably the 'first' or 'left' but also the 'captain' or only available recorded altimeter.",
+                                "units": "ft",
+                                "metadata": None
+                            },
+                            "color": "#000000"
+                        },
+                        {
+                            "chartIndex": 1,
+                            "analytic": {
+                                "id": "fake-gear_height-id-that-exists=",
+                                "name": "Best Estimate of Main Gear Height AGL (ft)",
+                                "description": "This is the best estimate of the height above ground level of the main gear.  If available, it will use the pitch, altimeter height and geometry constants to compute this height.  If these are not available, it will use the recorded/biased radar altimeter value as an estimate.",
+                                "units": "ft",
+                                "metadata": None
+                            },
+                            "color": "#0000FF"
+                        }
+                    ]
+                }
+        elif uri_keys == ('analyticSet', 'analytic_set_group'):
+            ems_id, group_id = uri_args
+            if group_id == 'root':
+                content = {
+                    "name": "Misc",
+                    "groupId": "Root",
+                    "groups": [
+                        {
+                            "name": "Mock Folder 1",
+                            "groupId": "Mock Folder 1",
+                            "groups": [],
+                            "sets": [],
+                            "collections": []
+                        },
+                        {
+                            "name": "Mock Folder 2",
+                            "groupId": "Mock Folder 2",
+                            "groups": [],
+                            "sets": [],
+                            "collections": []
+                        }
+                    ],
+                    "sets": [
+                        {
+                            "name": "Mock root parameter set 1"
+                        },
+                        {
+                            "name": "Mock root parameter set 2"
+                        }
+                    ],
+                    "collections": []
+                }
+            else:
+                content = {
+                    "name": group_id,
+                    "groupId": group_id,
+                    "groups": [
+                        {
+                            "name": "Mock Folder 1",
+                            "groupId": f"{group_id}:Mock Folder 1",
+                            "groups": [],
+                            "sets": [],
+                            "collections": []
+                        },
+                        {
+                            "name": "Mock Folder 2",
+                            "groupId": f"{group_id}:Mock Folder 2",
+                            "groups": [],
+                            "sets": [],
+                            "collections": []
+                        }
+                    ],
+                    "sets": [
+                        {
+                            "name": "Mock parameter set 1"
+                        },
+                        {
+                            "name": "Mock parameter set 2"
+                        }
+                    ],
+                    "collections": []
+                }
+
+
         return RESPONSE_HEADERS, content
 
 

--- a/tests/test_analyticset.py
+++ b/tests/test_analyticset.py
@@ -79,7 +79,7 @@ def test_get_analytic_set_set_does_not_exist(analyticset):
 
 def test_get_analytic_set_retieved_has_right_data(analyticset):
     df = analyticset.get_analytic_set('\path\mock set')
-    assert list(df) == analyticset._AnalyticSet__analytic_set_columns # Checking columns
+    assert len(list(df)) == len(analyticset._AnalyticSet__analytic_set_columns) # Checking the right number of columns
     assert len(df) == 3 # Expect 3 rows from the mock
 
 def test_get_group_content_retieved_has_right_data(analyticset):

--- a/tests/test_analyticset.py
+++ b/tests/test_analyticset.py
@@ -1,0 +1,89 @@
+import emspy, os, sys, pytest
+from emspy.query import LocalData
+from mock_connection import MockConnection
+from mock_ems import MockEMS
+from urllib.error import HTTPError
+
+
+@pytest.fixture
+def mocks(monkeypatch):
+    monkeypatch.setattr(emspy.query.query, 'EMS', MockEMS)
+    monkeypatch.setattr(emspy, 'Connection', MockConnection)
+
+
+@pytest.fixture
+def analyticset(mocks):
+    ems_id = 1
+    connection = MockConnection(user='', pwd='')
+    return emspy.query.AnalyticSet(connection, ems_id)
+
+# PATH TESTS
+def test_get_analytic_set_with_path_but_no_set(analyticset):
+    with pytest.raises(ValueError):
+        analyticset.get_analytic_set('path\to\set\\')
+
+def test_get_analytic_set_for_root_with_root_path(analyticset):
+    analyticset.get_analytic_set('root\set')
+    assert analyticset._group_id == 'root'
+    assert analyticset._analytic_set_id == 'set'
+
+def test_get_analytic_set_for_root_with_blank_path(analyticset):
+    analyticset.get_analytic_set("\set")
+    assert analyticset._group_id == 'root'
+    assert analyticset._analytic_set_id == 'set'
+
+def test_get_analytic_set_for_root_with_parameter_sets_path(analyticset):
+    analyticset.get_analytic_set('parameter sets\set')
+    assert analyticset._group_id == 'root'
+    assert analyticset._analytic_set_id == 'set'
+
+def test_get_analytic_set_using_backslashes(analyticset):
+    analyticset.get_analytic_set('\path\set')
+    assert analyticset._group_id == 'path'
+    assert analyticset._analytic_set_id == 'set'
+
+def test_get_analytic_set_using_backslashes_with_special_characters(analyticset):
+    analyticset.get_analytic_set('\folder\aet')
+    assert analyticset._group_id == 'folder'
+    assert analyticset._analytic_set_id == 'aet'
+
+def test_get_analytic_set_using_backslashes(analyticset):
+    analyticset.get_analytic_set('/folder/set')
+    assert analyticset._group_id == 'folder'
+    assert analyticset._analytic_set_id == 'set'
+
+def test_get_analytic_set_with_longer_path(analyticset):
+    analyticset.get_analytic_set('/folder1\folder2/folder3\set')
+    assert analyticset._group_id == 'folder1:folder2:folder3'
+    assert analyticset._analytic_set_id == 'set'
+
+def test_get_group_content_with_no_path(analyticset):
+    analyticset.get_group_content('root')
+    assert analyticset._analytic_set_path == 'root'
+
+def test_get_group_content_with_path(analyticset):
+    analyticset.get_group_content('\folder 1\folder 2\\')
+    assert analyticset._analytic_set_path == r'\folder 1\folder 2'+'\\'
+
+
+# QUERY TESTS
+
+def test_get_analytic_set_retieved_has_right_name(analyticset):
+    analyticset.get_analytic_set('\path\mock set')
+    assert analyticset._analytic_set_name == 'mock set'
+
+def test_get_analytic_set_set_does_not_exist(analyticset):
+    analyticset.get_analytic_set('\path\A PARAMETER SET THAT DOES NOT EXIST')
+    assert analyticset._analytic_set_name == None
+    assert analyticset._analytic_set_description == None
+
+def test_get_analytic_set_retieved_has_right_data(analyticset):
+    df = analyticset.get_analytic_set('\path\mock set')
+    assert list(df) == analyticset._AnalyticSet__analytic_set_columns # Checking columns
+    assert len(df) == 3 # Expect 3 rows from the mock
+
+def test_get_group_content_retieved_has_right_data(analyticset):
+    group_dict = analyticset.get_group_content('\path\\')
+    assert list(group_dict) == ['groups', 'sets']
+    assert len(group_dict['groups']) == 2 # Expect 2 groups from the mock
+    assert len(group_dict['sets']) == 2 # Expect 2 sets from the mock

--- a/tests/test_tsquery.py
+++ b/tests/test_tsquery.py
@@ -111,6 +111,18 @@ def test_analytic_id_with_lookup_using_select_ids_adds_name(tsq):
     tsq._TSeriesQuery__analytic._metadata.delete_all_tables()
 
 
+def test_select_from_pset_has_correct_ids(tsq):
+    expected_analytic_ids = ['fake-pres-alt-id-that-exists=','fake-rad-alt-id-that-exists=','fake-gear_height-id-that-exists=']
+    expected_analytic_names = ['Pressure Altitude (ft)','Radio Altitude (1, left, Capt or Only) (ft)','Best Estimate of Main Gear Height AGL (ft)']
+    tsq.select_from_pset('\path\set')
+    selects = tsq._TSeriesQuery__queryset['select']
+    columns = tsq._TSeriesQuery__columns
+    for id in selects:
+        assert id['analyticId'] in expected_analytic_ids
+    for column in columns:
+        assert column['name'] in expected_analytic_names
+
+
 # INCORRECT ID TESTS
 def test_analytic_id_doesnt_exist_with_lookup_using_select_ids(tsq):
     analytic_id = 'fake-pressure-alt-id-that-DOES-NOT-exist='

--- a/tests/test_tsquery.py
+++ b/tests/test_tsquery.py
@@ -122,6 +122,9 @@ def test_select_from_pset_has_correct_ids(tsq):
     for column in columns:
         assert column['name'] in expected_analytic_names
 
+    # destroy
+    tsq._TSeriesQuery__analytic._metadata.delete_all_tables()
+
 
 # INCORRECT ID TESTS
 def test_analytic_id_doesnt_exist_with_lookup_using_select_ids(tsq):


### PR DESCRIPTION
Completely refactored the AnalyticSet Class. I do not think this was working at all before. just instantiating an object would cause a failure, and it was never added to the query.__init__.py file.
There are three user facing methods that I added. 2 in the AnalyticSet class (get_analytic_set, get_group_content) and one in the TSeriesQuery class (select_from_pset).
Also updated the readMe

I bumped the version from 0.5.1 to 0.6.0. In theory an upgrade to the MINOR number should be backward compatible, and this would not really be except for the fact that I don't think that the AnalyticSet class ever worked, so I don't think anybody is actually using it. I could bump the MAJOR version, but that does not feel right for this.