### PR TITLE
Replace use of pandas append with concat

### DIFF
--- a/emspy/query/flight.py
+++ b/emspy/query/flight.py
@@ -275,7 +275,7 @@ class Flight(object):
             d1, d2 = self.__fl_request(parent)
 
         if len(d1) > 0:
-            self._trees[treetype] = self._trees[treetype].append(d1, ignore_index=True)
+            self._trees[treetype] = self._trees[treetype].concat(d1, axis=0, join='outer', ignore_index=True)
             plural = "s" if len(d1) > 1 else ""
             print("-- Added %d %s%s" % (len(d1), searchtype, plural))
 
@@ -283,7 +283,7 @@ class Flight(object):
             if exclude_subtrees:
                 print("-- Excluded subtree: %s" % x['name'])
             else:
-                self._trees[treetype] = self._trees[treetype].append(x, ignore_index=True)
+                self._trees[treetype] = self._trees[treetype].concat(x, axis=0, join='outer',  ignore_index=True)
                 if len(exclude_tree) > 0:
                     if all([y not in x['name'] for y in exclude_tree]):
                         self.__add_subtree(x, exclude_tree, treetype)
@@ -344,7 +344,7 @@ class Flight(object):
                                        & (tree.parent_id == parent['id']))]
 
         if len(d1) > 0:
-            self._trees[treetype] = self._trees[treetype].append(d1, ignore_index=True)
+            self._trees[treetype] = self._trees[treetype].concat(d1, axis=0, join='outer', ignore_index=True)
             plural = "s" if len(d1) > 1 else ""
             print("-- Added %d %s%s" % (len(d1), searchtype, plural))
 
@@ -522,7 +522,7 @@ class Flight(object):
                 if unique:
                     # If more than one value returned, choose one with the shortest name.
                     fres = _get_shortest(fres)
-            res = res.append(fres, ignore_index=True)
+            res = res.concat(fres, axis=0, join='outer', ignore_index=True)
 
         # Convert the search result to a list of dicts
         res = [x[1].to_dict() for x in res.iterrows()]

--- a/emspy/query/flight.py
+++ b/emspy/query/flight.py
@@ -581,7 +581,7 @@ class Flight(object):
                 'value': list(km.values())
             })
             kmap['key'] = pd.to_numeric(kmap['key'])
-            self._trees['kvmaps'] = self._trees['kvmaps'].append(kmap, ignore_index=True)
+            self._trees['kvmaps'] = self._trees['kvmaps'].concat(kmap, axis=0, join='outer', ignore_index=True, sort=True)
             self.__save_kvmaps()
 
         if in_dict:

--- a/emspy/query/fltquery.py
+++ b/emspy/query/fltquery.py
@@ -495,7 +495,7 @@ class FltQuery(Query):
             if ctr == 0:
                 df = dff
             else:
-                df = df.append(dff, ignore_index=True)
+                df = df.concat(dff, axis=0, join='outer', ignore_index=True)
 
             print("Received up to %d rows." % df.shape[0])
             if dff.shape[0] < n_row:

--- a/emspy/query/tsquery.py
+++ b/emspy/query/tsquery.py
@@ -213,7 +213,7 @@ class TSeriesQuery(Query):
                 prm = res_df.iloc[0, :].to_dict()
                 # Add the new parameters to the param table for later uses
                 self.__analytic._param_table = \
-                    self.__analytic._param_table.concat(res_df, axis=0, join='outer', ,ignore_index=True, sort=True)
+                    self.__analytic._param_table.concat(res_df, axis=0, join='outer', ignore_index=True, sort=True)
                 save_table = True
 
             # Put the param into JSON query string

--- a/emspy/query/tsquery.py
+++ b/emspy/query/tsquery.py
@@ -168,7 +168,7 @@ class TSeriesQuery(Query):
             df = pd.DataFrame(prm, index=[0])
 
             self.__analytic._param_table = \
-                self.__analytic._param_table.append(df, ignore_index=True, sort=True)
+                self.__analytic._param_table.concat(df, axis=0, join='outer', ignore_index=True, sort=True)
 
             # Put the param into JSON query string
             self.__queryset['select'].append({'analyticId': prm['id']})
@@ -213,7 +213,7 @@ class TSeriesQuery(Query):
                 prm = res_df.iloc[0, :].to_dict()
                 # Add the new parameters to the param table for later uses
                 self.__analytic._param_table = \
-                    self.__analytic._param_table.append(res_df, ignore_index=True, sort=True)
+                    self.__analytic._param_table.concat(res_df, axis=0, join='outer', ,ignore_index=True, sort=True)
                 save_table = True
 
             # Put the param into JSON query string
@@ -423,7 +423,7 @@ class TSeriesQuery(Query):
             res_df = self.__analytic.search_param("hours of data (hours)", in_df=True)
             p = res_df.iloc[0].to_dict()
             self.__analytic._param_table = \
-                self.__analytic._param_table.append(res_df, ignore_index=True, sort=True)
+                self.__analytic._param_table.concat(res_df, axis=0, join='outer', ignore_index=True, sort=True)
             self.__analytic._save_paramtable()
         q = {
             "select": [{"analyticId": p["id"]}],


### PR DESCRIPTION
Modern versions of pandas will complain about the use of `df.append` - it's been deprecated to `df.concat`. I've replaced all the instances of that I can find with the right pandas code.