### PR TITLE
Add fieldset endpoint and FltQuery.select_fieldset()

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.8
+current_version = 0.7.0
 commit = True
 tag = True
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,86 @@
+# Changelog
+
+## 0.7.0
+
+### New features
+
+- `FltQuery.select_fieldset(fieldset, group=None, aggregate='none')` expands a
+  server-curated fieldset into the query's select list in one call. Accepts
+  either a pre-fetched fieldset dict or a name; without `group`, walks the
+  fieldset-group tree depth-first to find a unique match. Fields are expanded
+  client-side into individual `{fieldId, aggregate}` entries - the `/query`
+  endpoint never sees the fieldset reference.
+- New `Fieldset` class (in `emspy/query/fieldset.py`) wraps the GE EMS
+  `/fieldset-groups` endpoint family. Exposes `get_groups()`,
+  `get_group(group_id)`, `get_fieldset(group_id, name)`, `find(name)` and
+  `clear_cache()`. Tolerates the observed response-shape variations
+  (`schemaItems` with `moniker`/`description` vs `fields` with `id`/`name`,
+  bare-string entries, bare-array vs envelope group listings).
+- `select_fieldset()` verifies that the fieldset's embedded
+  `[ems-...][entity-type][...]` token agrees with the query's currently
+  selected database; aborts with a clear message on mismatch or on a
+  fieldset that mixes fields from multiple databases. Skipped silently when
+  no database has been selected yet, or when field IDs lack an extractable
+  entity-type token.
+- `FltQuery.select_id(*field_ids, aggregate='none')` selects fields by their
+  id (moniker) directly, bypassing name-based metadata tree search. Faster
+  and unambiguous when the field id is already known. Backed by a new
+  `Flight.resolve_id()` that checks the local fieldtree cache first and
+  falls back to the EMS field API, caching the result.
+- `deselect()` now matches columns by field ID rather than full dict
+  equality, so fields added via the API fallback path of `select_id` (which
+  may have different keys than what `search_fields` returns) can be removed
+  cleanly.
+
+### Bug fixes
+
+- pandas 3.0 compatibility:
+  - Replace positional `df.iloc[:, i]` assignment with `df.isetitem(i, ...)`
+    for dtype conversions in `FltQuery.__to_dataframe()` (fixes `TypeError`
+    with PyArrow `StringDtype`).
+  - Widen the dtype-conversion `except` clause to catch `TypeError` in
+    addition to `ValueError`.
+  - Replace `inplace=True` with reassignment for Copy-on-Write compatibility
+    (`profile.py` `set_index`, `flight.py` `reset_index`).
+  - Fix empty-DataFrame `concat` pattern in `analyticset.py` using
+    `reindex`.
+  - Fix `.astype(int)` on a string column in `profile.py` using
+    `pd.to_numeric`.
+  - Fix invalid escape sequences in `analyticset.py` and
+    `test_analyticset.py`.
+  - Fix duplicate-column `TypeError` in `FltQuery.__to_dataframe` by
+    reading positionally via `df.iloc[:, i]` and writing via
+    `df.isetitem(i, ...)`.
+- Fix `np.int64` parameters breaking `sqlite3` queries under numpy 2.x.
+  Convert numpy scalar types to native Python types via `.item()` before
+  passing to `sqlite3` in `localdata.py` `get_data()` and `delete_data()`.
+- Fix SQL injection vulnerability in `query.set_database()` when database
+  names contain single quotes (e.g. `"GPWS: Don't Sink"`). `localdata.py`
+  `get_data()` and `delete_data()` now support parameterized queries via a
+  `(where_clause, params)` tuple; callers in `flight.py` and `analytic.py`
+  switched over. Backward compatible with the existing string-based API.
+- Fix `tsquery` `PerformanceWarning` for queries with many parameters by
+  building the result as a dict before constructing the DataFrame instead
+  of appending columns one by one. Ensure the `offsets` element exists in
+  the `tsQuery` run result.
+- Drop `path` and `displayPath` from `tsquery` select to fix indexing.
+- Several follow-up `pd.concat()` fixes across `FltQuery` query/mode paths.
+
+### Packaging / requirements
+
+- Drop Python 2.7 support from `setup.py` classifiers.
+- Add `pandas>=1.5` minimum-version constraint.
+- Add `smoke_test_*.py` to `.gitignore`.
+- Remove an auto-generated `pyproject.toml` that declared
+  `requires-python>=3.13` and broke CI.
+
+### Documentation
+
+- README: new "Selecting a fieldset" section showing the three call forms
+  for `select_fieldset()`.
+- README: new section documenting `select_id()`.
+- README: misc updates from 0.6.x.
+
+## 0.6.0
+
+Baseline for this changelog.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,12 +4,14 @@
 
 ### New features
 
-- `FltQuery.select_fieldset(fieldset, group=None, aggregate='none')` expands a
-  server-curated fieldset into the query's select list in one call. Accepts
-  either a pre-fetched fieldset dict or a name; without `group`, walks the
-  fieldset-group tree depth-first to find a unique match. Fields are expanded
-  client-side into individual `{fieldId, aggregate}` entries - the `/query`
-  endpoint never sees the fieldset reference.
+- `FltQuery.select_fieldset(fieldset, group=None)` expands a server-curated
+  fieldset into the query's select list in one call. Accepts either a
+  pre-fetched fieldset dict or a name; without `group`, walks the
+  fieldset-group tree depth-first to find a unique match (name matching is
+  case-insensitive). Fields are expanded client-side into individual
+  `{fieldId, aggregate='none'}` entries - the `/query` endpoint never sees
+  the fieldset reference. Aggregation is not exposed at the fieldset level;
+  use `select()` / `select_id()` for per-field aggregation.
 - New `Fieldset` class (in `emspy/query/fieldset.py`) wraps the GE EMS
   `/fieldset-groups` endpoint family. Exposes `get_groups()`,
   `get_group(group_id)`, `get_fieldset(group_id, name)`, `find(name)` and

--- a/NEWS.md
+++ b/NEWS.md
@@ -35,14 +35,13 @@
   substring against the field name as it appears in the select list. This
   fixes a gap where fields added via `select_fieldset()` or via the API
   fallback path of `select_id()` could not be removed. Raises `ValueError`
-  with the current selection listed if nothing matches.
+  with the current selection listed if nothing matches, and prints a line
+  naming the fields that were removed.
 
-  **Behavioural change:** the old `deselect()` went through `search_fields`
-  with `unique=True` and removed only the *shortest-named* matching field
-  when the keyword was ambiguous. The new `deselect()` removes **every**
-  selected field whose name contains the substring. Callers that relied on
-  the old single-removal semantics should pass an exact field id, or a
-  longer name fragment that uniquely identifies the target.
+  Default behaviour matches the pre-0.7 `search_fields(unique=True)`
+  semantics: when a substring matches more than one selected field, only
+  the shortest-named match is removed. Pass `all_matches=True` to remove
+  every matching field in a single call.
 
 ### Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,10 +29,20 @@
   and unambiguous when the field id is already known. Backed by a new
   `Flight.resolve_id()` that checks the local fieldtree cache first and
   falls back to the EMS field API, caching the result.
-- `deselect()` now matches columns by field ID rather than full dict
-  equality, so fields added via the API fallback path of `select_id` (which
-  may have different keys than what `search_fields` returns) can be removed
-  cleanly.
+- `deselect()` no longer requires the targeted field to be present in the
+  local fieldtree. It now matches the supplied keyword directly against the
+  current selection - first by exact field id, then by case-insensitive
+  substring against the field name as it appears in the select list. This
+  fixes a gap where fields added via `select_fieldset()` or via the API
+  fallback path of `select_id()` could not be removed. Raises `ValueError`
+  with the current selection listed if nothing matches.
+
+  **Behavioural change:** the old `deselect()` went through `search_fields`
+  with `unique=True` and removed only the *shortest-named* matching field
+  when the keyword was ambiguous. The new `deselect()` removes **every**
+  selected field whose name contains the substring. Callers that relied on
+  the old single-removal semantics should pass an exact field id, or a
+  longer name fragment that uniquely identifies the target.
 
 ### Bug fixes
 

--- a/README.md
+++ b/README.md
@@ -250,16 +250,12 @@ print(fs["fields"])  # DataFrame with id, name, and type columns
 query.select_fieldset(fs)
 ```
 
-`select_fieldset(...)` accepts the same `aggregate` keyword as `select(...)`.
-The aggregate is applied to every field in the fieldset:
-
-```python
-query.select_fieldset(
-    "Standard Flight Metrics",
-    group="<group-id>",
-    aggregate="avg"
-)
-```
+`select_fieldset(...)` does not accept an `aggregate` keyword - every field is
+added with `aggregate='none'`. If you need to aggregate, add the relevant
+fields individually via `select(...)` or `select_id(...)` with the appropriate
+per-field aggregation. (Applying one aggregation uniformly across a curated
+fieldset is rarely sensible, and some aggregations - e.g. `stdev` on datetime
+fields - are not processed correctly by the API.)
 
 Fieldsets are cached in memory for the life of the `Fieldset` object. Use
 `clear_cache()` if you need to force fresh API results:

--- a/README.md
+++ b/README.md
@@ -195,6 +195,50 @@ query.select_id(
 `select_id(...)` can be freely mixed with `select(...)` in the same query. If a field id is already present in the local metadata tree it is resolved from cache; otherwise it is looked up via the EMS API and cached for future use.
 
 
+### Selecting a fieldset
+
+A **fieldset** is a server-curated bundle of fields that an analyst has
+grouped together. Instead of looking up each field by name, you can ask
+EMS for the whole fieldset and expand it into your query's select list
+in one call. Fields added via a fieldset stack alongside fields added by
+`select()` — they all become individual entries in the underlying
+queryset.
+
+```python
+from emspy.query import Fieldset
+
+# Option A: by name only - walks the fieldset-group tree to find a unique
+# match. Raises ValueError if the name is ambiguous or unknown.
+query.select_fieldset("Standard Flight Metrics")
+
+# Option B: by name with an explicit group ID - skips the tree walk.
+query.select_fieldset("Standard Flight Metrics", group="<group-id>")
+
+# Option C: pre-fetch the fieldset, then apply it. Useful when you want
+# to inspect the field list first or reuse the same fieldset across
+# queries without re-fetching.
+fs = Fieldset(conn, query.get_ems_id()).get_fieldset(
+    "<group-id>", "Standard Flight Metrics"
+)
+print(fs['fields'])           # DataFrame of id / name / type
+query.select_fieldset(fs)
+```
+
+`select_fieldset()` accepts the same `aggregate` keyword as `select()`,
+applied uniformly to every field in the fieldset.
+
+To discover what's available, the `Fieldset` class exposes three
+listing methods (results are cached in-memory per session):
+
+```python
+fset = Fieldset(conn, ems_id)
+fset.get_groups()                                 # top-level groups
+fset.get_group("<group-id>")                      # groups + fieldsets in a group
+fset.get_fieldset("<group-id>", "<fieldset-name>")  # fields in a fieldset
+fset.find("My Fieldset")                          # depth-first search by name
+fset.clear_cache()
+```
+
 ### Group by & Order by
 Similarly, you can pass the grouping and ordering condition:
 

--- a/README.md
+++ b/README.md
@@ -197,47 +197,80 @@ query.select_id(
 
 ### Selecting a fieldset
 
-A **fieldset** is a server-curated bundle of fields that an analyst has
-grouped together. Instead of looking up each field by name, you can ask
-EMS for the whole fieldset and expand it into your query's select list
-in one call. Fields added via a fieldset stack alongside fields added by
-`select()` — they all become individual entries in the underlying
-queryset.
+A **fieldset** is a server-curated bundle of fields. `select_fieldset(...)`
+fetches a fieldset and expands it into the query as normal `{fieldId,
+aggregate}` select entries. The query endpoint does not receive a fieldset
+reference; it receives the individual field IDs.
+
+Fieldset selection can be mixed with `select(...)` and `select_id(...)` in the
+same query:
+
+```python
+query.select("Flight Record")
+query.select_id(
+    "[-hub-][field][[[ems-core][entity-type][foqa-flights]][[ems-core][base-field][flight.uid]]]"
+)
+query.select_fieldset("Standard Flight Metrics", group="<group-id>")
+```
+
+If you know the fieldset group ID, pass it with `group=...`. This is the
+fastest and most predictable form because it avoids walking the full
+fieldset-group tree:
+
+```python
+query.select_fieldset("Standard Flight Metrics", group="<group-id>")
+```
+
+If you do not know the group ID, you can pass only the fieldset name. emsPy
+will search visible fieldset groups and require a single match:
+
+```python
+query.select_fieldset("Standard Flight Metrics")
+```
+
+This raises `ValueError` if no visible fieldset has that name, or if the name
+appears in more than one group. In that case, find the fieldset and pass
+`group=` explicitly.
+
+Use `Fieldset` directly when you want to inspect available groups or preview
+the field list before adding it to a query:
 
 ```python
 from emspy.query import Fieldset
 
-# Option A: by name only - walks the fieldset-group tree to find a unique
-# match. Raises ValueError if the name is ambiguous or unknown.
-query.select_fieldset("Standard Flight Metrics")
+fieldsets = Fieldset(conn, query.get_ems_id())
 
-# Option B: by name with an explicit group ID - skips the tree walk.
-query.select_fieldset("Standard Flight Metrics", group="<group-id>")
+groups = fieldsets.get_groups()
+contents = fieldsets.get_group("<group-id>")
+matches = fieldsets.find("Standard Flight Metrics")
 
-# Option C: pre-fetch the fieldset, then apply it. Useful when you want
-# to inspect the field list first or reuse the same fieldset across
-# queries without re-fetching.
-fs = Fieldset(conn, query.get_ems_id()).get_fieldset(
-    "<group-id>", "Standard Flight Metrics"
-)
-print(fs['fields'])           # DataFrame of id / name / type
+fs = fieldsets.get_fieldset("<group-id>", "Standard Flight Metrics")
+print(fs["fields"])  # DataFrame with id, name, and type columns
+
 query.select_fieldset(fs)
 ```
 
-`select_fieldset()` accepts the same `aggregate` keyword as `select()`,
-applied uniformly to every field in the fieldset.
-
-To discover what's available, the `Fieldset` class exposes three
-listing methods (results are cached in-memory per session):
+`select_fieldset(...)` accepts the same `aggregate` keyword as `select(...)`.
+The aggregate is applied to every field in the fieldset:
 
 ```python
-fset = Fieldset(conn, ems_id)
-fset.get_groups()                                 # top-level groups
-fset.get_group("<group-id>")                      # groups + fieldsets in a group
-fset.get_fieldset("<group-id>", "<fieldset-name>")  # fields in a fieldset
-fset.find("My Fieldset")                          # depth-first search by name
-fset.clear_cache()
+query.select_fieldset(
+    "Standard Flight Metrics",
+    group="<group-id>",
+    aggregate="avg"
+)
 ```
+
+Fieldsets are cached in memory for the life of the `Fieldset` object. Use
+`clear_cache()` if you need to force fresh API results:
+
+```python
+fieldsets.clear_cache()
+```
+
+When a query already has a selected database, emsPy checks shaped field IDs in
+the fieldset against that database and raises `ValueError` if the fieldset
+targets a different database or mixes fields from multiple databases.
 
 ### Group by & Order by
 Similarly, you can pass the grouping and ordering condition:

--- a/emspy/__init__.py
+++ b/emspy/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from .connection import Connection 
 
-__version__ = "0.6.9"
+__version__ = "0.7.0"

--- a/emspy/common.py
+++ b/emspy/common.py
@@ -62,5 +62,10 @@ uris = {
         'analytic_set_groups': '/v2/ems-systems/%s/analytic-set-groups',  # (emsSystemId),
         'analytic_set_group': '/v2/ems-systems/%s/analytic-set-groups/%s',  # (emsSystemId, groupId)
         'analytic_set': '/v2/ems-systems/%s/analytic-set-groups/%s/analytic-sets/%s',  # (emsSystemId, groupId, analyticSetName)
+    },
+    'fieldset': {
+        'fieldset_groups': '/v2/ems-systems/%s/fieldset-groups',  # (emsSystemId)
+        'fieldset_group': '/v2/ems-systems/%s/fieldset-groups/%s',  # (emsSystemId, groupId)
+        'fieldset': '/v2/ems-systems/%s/fieldset-groups/%s/fieldset/%s',  # (emsSystemId, groupId, fieldsetName)
     }
 }

--- a/emspy/query/__init__.py
+++ b/emspy/query/__init__.py
@@ -11,4 +11,5 @@ from emspy.query.tsquery import TSeriesQuery
 from emspy.query.profile import Profile
 from emspy.query.dbmodify import InsertQuery
 from emspy.query.analyticset import AnalyticSet
+from emspy.query.fieldset import Fieldset
 

--- a/emspy/query/fieldset.py
+++ b/emspy/query/fieldset.py
@@ -1,11 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
-
-import sys
-if sys.version_info < (3, 0):
-    from future import standard_library
-    standard_library.install_aliases()
-
 from urllib.error import HTTPError
 
 import pandas as pd
@@ -97,10 +89,11 @@ class Fieldset(Asset):
         """
         List the top-level fieldset groups available on the EMS system.
 
-        Returns a DataFrame with columns: id, name, description.
+        Returns a DataFrame with columns: id, name, description. Cached
+        results are returned as copies so callers cannot mutate the cache.
         """
         if not refresh and self._root_cache is not None:
-            return self._root_cache
+            return self._root_cache.copy()
 
         _, result = self._conn.request(
             uri_keys=('fieldset', 'fieldset_groups'),
@@ -121,7 +114,7 @@ class Fieldset(Asset):
             df = df[['id', 'name', 'description']]
 
         self._root_cache = df
-        return df
+        return df.copy()
 
     def get_group(self, group_id, refresh=False):
         """
@@ -135,7 +128,7 @@ class Fieldset(Asset):
             raise ValueError("group_id must be a non-empty string.")
 
         if not refresh and group_id in self._group_cache:
-            return self._group_cache[group_id]
+            return self._group_cache[group_id].copy()
 
         _, result = self._conn.request(
             uri_keys=('fieldset', 'fieldset_group'),
@@ -178,7 +171,7 @@ class Fieldset(Asset):
             )
 
         self._group_cache[group_id] = df
-        return df
+        return df.copy()
 
     def get_fieldset(self, group_id, fieldset_name, refresh=False):
         """
@@ -199,7 +192,7 @@ class Fieldset(Asset):
 
         key = (group_id, fieldset_name)
         if not refresh and key in self._fieldset_cache:
-            return self._fieldset_cache[key]
+            return self._copy_fieldset(self._fieldset_cache[key])
 
         _, result = self._conn.request(
             uri_keys=('fieldset', 'fieldset'),
@@ -224,7 +217,19 @@ class Fieldset(Asset):
             'fields': fields_df,
         }
         self._fieldset_cache[key] = fs
-        return fs
+        return self._copy_fieldset(fs)
+
+    @staticmethod
+    def _copy_fieldset(fs):
+        # Shallow-copy the dict with a fresh DataFrame so mutations to the
+        # returned value (e.g. ``fs['fields'].drop(...)``) don't bleed
+        # into the cache.
+        return {
+            'name': fs['name'],
+            'group_id': fs['group_id'],
+            'ems_id': fs['ems_id'],
+            'fields': fs['fields'].copy(),
+        }
 
     def find(self, fieldset_name, max_depth=6):
         """

--- a/emspy/query/fieldset.py
+++ b/emspy/query/fieldset.py
@@ -265,12 +265,17 @@ class Fieldset(Asset):
             if contents is None or len(contents) == 0:
                 return
 
+            target = fieldset_name.lower()
             fs_rows = contents[
                 (contents['type'] == 'fieldset')
-                & (contents['name'] == fieldset_name)
+                & (contents['name'].str.lower() == target)
             ]
-            if len(fs_rows) > 0:
-                hits.append({'group_id': gid, 'path': list(path)})
+            for _, fs_row in fs_rows.iterrows():
+                hits.append({
+                    'group_id': gid,
+                    'name': fs_row['name'],
+                    'path': list(path),
+                })
 
             sub_rows = contents[contents['type'] == 'group']
             for _, row in sub_rows.iterrows():

--- a/emspy/query/fieldset.py
+++ b/emspy/query/fieldset.py
@@ -1,0 +1,288 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+import sys
+if sys.version_info < (3, 0):
+    from future import standard_library
+    standard_library.install_aliases()
+
+from urllib.error import HTTPError
+
+import pandas as pd
+
+from .asset import Asset
+
+
+# Response parsing helpers ---------------------------------------------------
+
+def _first(d, *keys):
+    # Tolerant key lookup: returns the first non-None value among d[k1], d[k2], ...
+    # Mirrors the R %||% operator used in Rems2.
+    if not isinstance(d, dict):
+        return None
+    for k in keys:
+        if k in d and d[k] is not None:
+            return d[k]
+    return None
+
+
+def _parse_fieldset_group_entry(d):
+    return {
+        'id': _first(d, 'id', 'groupId', 'group_id'),
+        'name': _first(d, 'name'),
+        'description': _first(d, 'description'),
+    }
+
+
+def _parse_fieldset_entry(d):
+    # Slim summary form that appears in group listings.
+    return {
+        'id': _first(d, 'id', 'name'),
+        'name': _first(d, 'name'),
+        'description': _first(d, 'description'),
+    }
+
+
+def _parse_fieldset_fields(fields):
+    # Direct port of Rems2's parse_fieldset_fields. Tolerates schemaItems with
+    # moniker/description, or fields with id/name, or bare-string entries.
+    cols = {'id': [], 'name': [], 'type': []}
+    if not fields:
+        return pd.DataFrame(cols, columns=['id', 'name', 'type'])
+
+    for f in fields:
+        if isinstance(f, str):
+            cols['id'].append(f)
+            cols['name'].append(None)
+            cols['type'].append(None)
+            continue
+        if not isinstance(f, dict):
+            continue
+        cols['id'].append(_first(f, 'moniker', 'id', 'fieldId'))
+        cols['name'].append(_first(f, 'description', 'name'))
+        cols['type'].append(_first(f, 'type', 'dataType', 'data_type'))
+
+    return pd.DataFrame(cols, columns=['id', 'name', 'type'])
+
+
+# Fieldset class -------------------------------------------------------------
+
+class Fieldset(Asset):
+    """
+    Server-curated bundles of fields exposed by the EMS fieldset-groups API.
+
+    Fieldsets are metadata only: the /query endpoint does not accept a
+    fieldset reference, so a fieldset is "applied" client-side by expanding
+    its fields into a FltQuery's select list. See FltQuery.select_fieldset.
+
+    Parameters
+    ----------
+    conn : emspy.connection.Connection
+        Connection object.
+    ems_id : int
+        EMS system ID.
+    """
+
+    def __init__(self, conn, ems_id):
+        Asset.__init__(self, conn, "Fieldset")
+        self._ems_id = ems_id
+        # Session-level caches; mirrors Rems2's pkg_env$fieldset_cache structure.
+        self._root_cache = None                  # DataFrame of groups, or None
+        self._group_cache = {}                   # group_id -> DataFrame
+        self._fieldset_cache = {}                # (group_id, name) -> dict
+
+    # Public API -------------------------------------------------------------
+
+    def get_groups(self, refresh=False):
+        """
+        List the top-level fieldset groups available on the EMS system.
+
+        Returns a DataFrame with columns: id, name, description.
+        """
+        if not refresh and self._root_cache is not None:
+            return self._root_cache
+
+        _, result = self._conn.request(
+            uri_keys=('fieldset', 'fieldset_groups'),
+            uri_args=self._ems_id,
+        )
+        # Tolerate either bare-array or {'groups': [...]} envelope.
+        group_list = result.get('groups') if isinstance(result, dict) else result
+        if group_list is None:
+            group_list = result if isinstance(result, list) else []
+
+        if not group_list:
+            df = pd.DataFrame({'id': [], 'name': [], 'description': []},
+                              columns=['id', 'name', 'description'])
+        else:
+            df = pd.DataFrame.from_records(
+                [_parse_fieldset_group_entry(x) for x in group_list]
+            )
+            df = df[['id', 'name', 'description']]
+
+        self._root_cache = df
+        return df
+
+    def get_group(self, group_id, refresh=False):
+        """
+        Get a single fieldset group's contents.
+
+        Returns a DataFrame with columns: type (group|fieldset), id, name,
+        description. The id for a fieldset row is its name (which is what
+        the API expects in subsequent calls).
+        """
+        if not isinstance(group_id, str) or not group_id:
+            raise ValueError("group_id must be a non-empty string.")
+
+        if not refresh and group_id in self._group_cache:
+            return self._group_cache[group_id]
+
+        _, result = self._conn.request(
+            uri_keys=('fieldset', 'fieldset_group'),
+            uri_args=(self._ems_id, group_id),
+        )
+
+        subgroups = result.get('groups') or []
+        fieldsets = (
+            result.get('fieldSets')
+            or result.get('fieldsets')
+            or result.get('field_sets')
+            or []
+        )
+
+        rows = []
+        for g in subgroups:
+            entry = _parse_fieldset_group_entry(g)
+            rows.append({
+                'type': 'group',
+                'id': entry['id'],
+                'name': entry['name'],
+                'description': entry['description'],
+            })
+        for f in fieldsets:
+            entry = _parse_fieldset_entry(f)
+            rows.append({
+                'type': 'fieldset',
+                'id': entry['id'],
+                'name': entry['name'],
+                'description': entry['description'],
+            })
+
+        if rows:
+            df = pd.DataFrame.from_records(rows)
+            df = df[['type', 'id', 'name', 'description']]
+        else:
+            df = pd.DataFrame(
+                {'type': [], 'id': [], 'name': [], 'description': []},
+                columns=['type', 'id', 'name', 'description'],
+            )
+
+        self._group_cache[group_id] = df
+        return df
+
+    def get_fieldset(self, group_id, fieldset_name, refresh=False):
+        """
+        Fetch a single fieldset.
+
+        Returns a dict:
+            {
+                'name': str,
+                'group_id': str,
+                'ems_id': int,
+                'fields': DataFrame with columns id, name, type
+            }
+        """
+        if not isinstance(group_id, str) or not group_id:
+            raise ValueError("group_id must be a non-empty string.")
+        if not isinstance(fieldset_name, str) or not fieldset_name:
+            raise ValueError("fieldset_name must be a non-empty string.")
+
+        key = (group_id, fieldset_name)
+        if not refresh and key in self._fieldset_cache:
+            return self._fieldset_cache[key]
+
+        _, result = self._conn.request(
+            uri_keys=('fieldset', 'fieldset'),
+            uri_args=(self._ems_id, group_id, fieldset_name),
+        )
+
+        raw_fields = result.get('schemaItems')
+        if raw_fields is None:
+            raw_fields = result.get('fields')
+        if raw_fields is None:
+            print("-- Warning: fieldset '%s' response has no recognised "
+                  "field list (expected 'schemaItems' or 'fields')."
+                  % fieldset_name)
+            raw_fields = []
+
+        fields_df = _parse_fieldset_fields(raw_fields)
+
+        fs = {
+            'name': result.get('name') or fieldset_name,
+            'group_id': group_id,
+            'ems_id': self._ems_id,
+            'fields': fields_df,
+        }
+        self._fieldset_cache[key] = fs
+        return fs
+
+    def find(self, fieldset_name, max_depth=6):
+        """
+        Depth-first search across all visible groups for a fieldset by name.
+
+        Returns a list of {'group_id': str, 'path': [str, ...]} dicts, one per
+        group whose immediate contents contain a fieldset matching
+        fieldset_name. Permission-gated subgroups are silently skipped.
+        """
+        if not isinstance(fieldset_name, str) or not fieldset_name:
+            raise ValueError("fieldset_name must be a non-empty string.")
+
+        hits = []
+        groups = self.get_groups()
+        if len(groups) == 0:
+            return hits
+
+        def visit(gid, path, depth):
+            if depth > max_depth:
+                return
+            try:
+                contents = self.get_group(gid)
+            except Exception as e:
+                # Permission-gated or otherwise inaccessible: skip but tell
+                # the user, so the HTTP error noise printed by the connection
+                # layer doesn't look like a failure of find() itself.
+                group_label = path[-1] if path else gid
+                if isinstance(e, HTTPError):
+                    reason = "HTTP %d %s" % (e.code, e.reason)
+                else:
+                    reason = str(e) or type(e).__name__
+                print(
+                    "-- Skipping fieldset group '%s' (id=%s) during tree "
+                    "walk: %s. Continuing search."
+                    % (group_label, gid, reason)
+                )
+                return
+            if contents is None or len(contents) == 0:
+                return
+
+            fs_rows = contents[
+                (contents['type'] == 'fieldset')
+                & (contents['name'] == fieldset_name)
+            ]
+            if len(fs_rows) > 0:
+                hits.append({'group_id': gid, 'path': list(path)})
+
+            sub_rows = contents[contents['type'] == 'group']
+            for _, row in sub_rows.iterrows():
+                visit(row['id'], path + [row['name']], depth + 1)
+
+        for _, row in groups.iterrows():
+            visit(row['id'], [row['name']], depth=1)
+
+        return hits
+
+    def clear_cache(self):
+        """Empty the in-memory cache so subsequent calls re-fetch from the API."""
+        self._root_cache = None
+        self._group_cache = {}
+        self._fieldset_cache = {}

--- a/emspy/query/flight.py
+++ b/emspy/query/flight.py
@@ -194,6 +194,13 @@ class Flight(object):
         tree = self._trees['dbtree']
         return tree[(tree.nodetype == "database") & (tree.id == self._db_id)].iloc[0].to_dict()
 
+    def get_db_id(self):
+        """
+        Return the currently selected database id, or None if no database
+        has been selected yet.
+        """
+        return self._db_id
+
     def __db_request(self, parent):
         body = None
         if parent['nodetype'] == "database_group":

--- a/emspy/query/fltquery.py
+++ b/emspy/query/fltquery.py
@@ -152,6 +152,13 @@ class FltQuery(Query):
         metadata tree search. This is faster and avoids ambiguity when the
         field id is already known.
 
+        Each id that is not already in the local fieldtree cache triggers
+        one ``/ems-systems/<ems_id>/databases/<db_id>/fields/<field_id>``
+        API call via ``Flight.resolve_id`` (the result is cached for the
+        rest of the session). For bulk selection of many uncached ids,
+        consider calling ``update_fieldtree(...)`` first to prime the
+        cache in a single tree walk.
+
         Parameters
         ----------
         args:
@@ -289,7 +296,8 @@ class FltQuery(Query):
         # Skipped silently when no database has been selected yet (the user can
         # call set_database() later) or when no field IDs carry an extractable
         # entity-type token (e.g. mock/test field IDs).
-        if getattr(self.__flight, '_db_id', None) is None:
+        query_db = self.__flight.get_db_id()
+        if query_db is None:
             return
 
         entity_types = []
@@ -309,7 +317,6 @@ class FltQuery(Query):
             )
 
         expected_db = unique_types[0]
-        query_db = self.__flight._db_id
         # Tolerate stray whitespace on user-supplied database IDs (a common
         # copy/paste hazard). Case and bracket structure remain significant:
         # entity tokens embed case-sensitive UUID / profile hashes.
@@ -323,37 +330,63 @@ class FltQuery(Query):
                 % (fs.get('name', '<unknown>'), query_db, expected_db)
             )
 
-    def deselect(self, *args):
+    def deselect(self, *args, **kwargs):
         """
         Remove fields from the current selection.
 
         For each argument, match against the currently-selected fields:
         first by exact field id, then by case-insensitive substring against
-        the selected field name. Raises ``ValueError`` listing the current
-        selection if neither pass finds a match.
+        the selected field name. No fieldtree lookup is involved, so this
+        works uniformly for fields added via ``select()``, ``select_id()``,
+        or ``select_fieldset()``.
 
-        No fieldtree lookup is involved, so this works uniformly for fields
-        added via ``select()``, ``select_id()``, or ``select_fieldset()``.
+        When a substring matches more than one selected field, by default
+        only the single shortest-named match is removed (preserving the
+        pre-0.7 ``unique=True`` ``search_fields`` semantics). Pass
+        ``all_matches=True`` to remove every matching field.
+
+        Raises ``ValueError`` if no field matches.
 
         Parameters
         ----------
         args:
             Field ids (exact) or substrings of selected field names.
 
+        Keyword arguments
+        -----------------
+        all_matches: bool
+            If True, remove every selected field whose name contains the
+            substring. Default False (remove only the shortest-named match).
+
         Returns
         -------
         None
         """
+        all_matches = kwargs.pop('all_matches', False)
+        if kwargs:
+            raise TypeError(
+                "deselect() got unexpected keyword arguments: %s"
+                % list(kwargs.keys())
+            )
+
         for arg in args:
-            ids_to_remove = {c['id'] for c in self.__columns if c.get('id') == arg}
-            if not ids_to_remove and isinstance(arg, string_types):
+            # Pass 1: exact id match (unambiguous).
+            matched = [c for c in self.__columns if c.get('id') == arg]
+
+            # Pass 2: case-insensitive substring match on the column name.
+            if not matched and isinstance(arg, string_types):
                 arg_lower = arg.lower()
-                ids_to_remove = {
-                    c['id'] for c in self.__columns
+                matched = [
+                    c for c in self.__columns
                     if isinstance(c.get('name'), string_types)
                     and arg_lower in c['name'].lower()
-                }
-            if not ids_to_remove:
+                ]
+                # Default to legacy single-removal: keep only the
+                # shortest-named match unless caller opted in to all.
+                if len(matched) > 1 and not all_matches:
+                    matched = [min(matched, key=lambda c: len(c['name']))]
+
+            if not matched:
                 preview = [{'id': c.get('id'), 'name': c.get('name')}
                            for c in self.__columns[:10]]
                 extra = len(self.__columns) - len(preview)
@@ -364,11 +397,21 @@ class FltQuery(Query):
                     "selected field name. Currently selected: %s%s"
                     % (arg, preview, tail)
                 )
+
+            ids_to_remove = {c['id'] for c in matched}
             self.__queryset['select'] = [
                 d for d in self.__queryset['select']
                 if d['fieldId'] not in ids_to_remove
             ]
             self.__columns = [c for c in self.__columns if c['id'] not in ids_to_remove]
+
+            removed = [(c.get('name') or c.get('id'), c.get('id')) for c in matched]
+            if len(removed) == 1:
+                print("-- Deselected '%s' (%s)." % removed[0])
+            else:
+                print("-- Deselected %d fields: %s"
+                      % (len(removed),
+                         ", ".join("'%s' (%s)" % r for r in removed)))
 
     def group_by(self, *args):
         """

--- a/emspy/query/fltquery.py
+++ b/emspy/query/fltquery.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import json
+import re
 import sys
 from builtins import str
 from builtins import zip
@@ -13,6 +14,20 @@ from future.utils import string_types
 from emspy.query import *
 from .query import Query
 from .fieldset import Fieldset
+
+
+# Field IDs embed the source entity-type as a `[ems-...][entity-type][...]`
+# token, which is also the form returned by /database-groups and used as
+# Flight._db_id. This helper extracts that token so a fieldset's fields can
+# be compared against the query's selected database.
+_ENTITY_TYPE_RE = re.compile(r"\[ems-[a-z0-9]+\]\[entity-type\]\[[^\]]+\]")
+
+
+def _extract_field_entity_type(field_id):
+    if not isinstance(field_id, string_types):
+        return None
+    m = _ENTITY_TYPE_RE.search(field_id)
+    return m.group(0) if m else None
 
 
 class FltQuery(Query):
@@ -216,6 +231,8 @@ class FltQuery(Query):
                   % fs.get('name', '<unknown>'))
             return
 
+        self._verify_fieldset_database_match(fs)
+
         added = 0
         for _, row in fields_df.iterrows():
             field_id = row.get('id')
@@ -267,6 +284,44 @@ class FltQuery(Query):
                 % (fieldset, '\n  '.join(paths))
             )
         return self.__fieldset.get_fieldset(hits[0]['group_id'], fieldset)
+
+    def _verify_fieldset_database_match(self, fs):
+        # Skipped silently when no database has been selected yet (the user can
+        # call set_database() later) or when no field IDs carry an extractable
+        # entity-type token (e.g. mock/test field IDs).
+        if getattr(self.__flight, '_db_id', None) is None:
+            return
+
+        entity_types = []
+        for fid in fs['fields']['id'].tolist():
+            et = _extract_field_entity_type(fid)
+            if et:
+                entity_types.append(et)
+        if not entity_types:
+            return
+
+        unique_types = sorted(set(entity_types))
+        if len(unique_types) > 1:
+            raise ValueError(
+                "Fieldset '%s' mixes fields from multiple databases; cannot "
+                "apply as a single select. Distinct source databases:\n  %s"
+                % (fs.get('name', '<unknown>'), '\n  '.join(unique_types))
+            )
+
+        expected_db = unique_types[0]
+        query_db = self.__flight._db_id
+        # Tolerate stray whitespace on user-supplied database IDs (a common
+        # copy/paste hazard). Case and bracket structure remain significant:
+        # entity tokens embed case-sensitive UUID / profile hashes.
+        if query_db.strip() != expected_db.strip():
+            raise ValueError(
+                "Fieldset '%s' targets a different database than this query.\n"
+                "  Query database:    %s\n"
+                "  Fieldset database: %s\n"
+                "Rebuild the query with set_database() on the fieldset's "
+                "database, or pick a fieldset for the current database."
+                % (fs.get('name', '<unknown>'), query_db, expected_db)
+            )
 
     def deselect(self, *args):
         """

--- a/emspy/query/fltquery.py
+++ b/emspy/query/fltquery.py
@@ -191,13 +191,20 @@ class FltQuery(Query):
             self.__queryset['select'].append(d)
             self.__columns.append(field)
 
-    def select_fieldset(self, fieldset, group=None, aggregate='none'):
+    def select_fieldset(self, fieldset, group=None):
         """
         Expand a server-curated fieldset into the query's select list.
 
         Fields are expanded client-side: every field in the fieldset is
-        appended as an individual {fieldId, aggregate} entry. The /query
-        endpoint never sees the fieldset reference.
+        appended as an individual {fieldId, aggregate} entry with
+        aggregate='none'. The /query endpoint never sees the fieldset
+        reference.
+
+        Aggregation is intentionally not exposed here: applying a single
+        aggregation uniformly across every field in a curated fieldset is
+        rarely sensible, and some aggregations (e.g. stdev on datetime
+        fields) are not processed correctly by the API. To aggregate, add
+        the relevant fields individually via select() or select_id().
 
         Parameters
         ----------
@@ -205,12 +212,9 @@ class FltQuery(Query):
             Either a fieldset name (str) or a pre-fetched fieldset dict
             returned by Fieldset.get_fieldset. If a name is given without
             `group`, the fieldset-group tree is walked to find a unique
-            match.
+            match (name matching is case-insensitive).
         group: str, optional
             Fieldset-group ID. Skips the tree walk when `fieldset` is a name.
-        aggregate: str, optional
-            Aggregation function applied to every field. Default 'none'.
-            Same allowlist as select().
 
         Examples
         --------
@@ -219,10 +223,6 @@ class FltQuery(Query):
         >>> fs = Fieldset(conn, ems_id).get_fieldset("<group-id>", "Standard Flight Metrics")
         >>> query.select_fieldset(fs)
         """
-        aggs = ['none', 'avg', 'count', 'max', 'min', 'stdev', 'sum', 'var']
-        if aggregate not in aggs:
-            sys.exit("Wrong aggregation selected. Use one of %s." % aggs)
-
         fs = self._resolve_fieldset_arg(fieldset, group)
         fields_df = fs['fields']
 
@@ -242,7 +242,7 @@ class FltQuery(Query):
                 continue
             self.__queryset['select'].append({
                 'fieldId': field_id,
-                'aggregate': aggregate,
+                'aggregate': 'none',
             })
             self.__columns.append({
                 'id': field_id,
@@ -283,7 +283,7 @@ class FltQuery(Query):
                 "Pass `group` explicitly to disambiguate."
                 % (fieldset, '\n  '.join(paths))
             )
-        return self.__fieldset.get_fieldset(hits[0]['group_id'], fieldset)
+        return self.__fieldset.get_fieldset(hits[0]['group_id'], hits[0]['name'])
 
     def _verify_fieldset_database_match(self, fs):
         # Skipped silently when no database has been selected yet (the user can

--- a/emspy/query/fltquery.py
+++ b/emspy/query/fltquery.py
@@ -325,25 +325,50 @@ class FltQuery(Query):
 
     def deselect(self, *args):
         """
-        Removes fields from the query
+        Remove fields from the current selection.
+
+        For each argument, match against the currently-selected fields:
+        first by exact field id, then by case-insensitive substring against
+        the selected field name. Raises ``ValueError`` listing the current
+        selection if neither pass finds a match.
+
+        No fieldtree lookup is involved, so this works uniformly for fields
+        added via ``select()``, ``select_id()``, or ``select_fieldset()``.
 
         Parameters
         ----------
         args:
-            fields to remove
+            Field ids (exact) or substrings of selected field names.
 
         Returns
         -------
         None
         """
-        fields = self.__flight.search_fields(*args)
-        if not isinstance(fields, list):
-            fields = [fields]
-        for field in fields:
-            matching_entries = [d for d in self.__queryset['select'] if d['fieldId'] == field['id']]
-            for entry in matching_entries:
-                self.__queryset['select'].remove(entry)
-            self.__columns = [c for c in self.__columns if c['id'] != field['id']]
+        for arg in args:
+            ids_to_remove = {c['id'] for c in self.__columns if c.get('id') == arg}
+            if not ids_to_remove and isinstance(arg, string_types):
+                arg_lower = arg.lower()
+                ids_to_remove = {
+                    c['id'] for c in self.__columns
+                    if isinstance(c.get('name'), string_types)
+                    and arg_lower in c['name'].lower()
+                }
+            if not ids_to_remove:
+                preview = [{'id': c.get('id'), 'name': c.get('name')}
+                           for c in self.__columns[:10]]
+                extra = len(self.__columns) - len(preview)
+                tail = (" ...and %d more" % extra) if extra > 0 else ""
+                raise ValueError(
+                    "deselect(%r): no matching field in the current selection. "
+                    "Pass either the exact field id or a substring of the "
+                    "selected field name. Currently selected: %s%s"
+                    % (arg, preview, tail)
+                )
+            self.__queryset['select'] = [
+                d for d in self.__queryset['select']
+                if d['fieldId'] not in ids_to_remove
+            ]
+            self.__columns = [c for c in self.__columns if c['id'] not in ids_to_remove]
 
     def group_by(self, *args):
         """

--- a/emspy/query/fltquery.py
+++ b/emspy/query/fltquery.py
@@ -12,6 +12,7 @@ from future.utils import string_types
 
 from emspy.query import *
 from .query import Query
+from .fieldset import Fieldset
 
 
 class FltQuery(Query):
@@ -38,6 +39,7 @@ class FltQuery(Query):
     def _init_assets(self, data_file):
         # Query._init_assets(self)
         self.__flight = Flight(self._conn, self._ems_id, data_file)
+        self.__fieldset = Fieldset(self._conn, self._ems_id)
 
     def set_database(self, name):
         """
@@ -173,6 +175,98 @@ class FltQuery(Query):
             }
             self.__queryset['select'].append(d)
             self.__columns.append(field)
+
+    def select_fieldset(self, fieldset, group=None, aggregate='none'):
+        """
+        Expand a server-curated fieldset into the query's select list.
+
+        Fields are expanded client-side: every field in the fieldset is
+        appended as an individual {fieldId, aggregate} entry. The /query
+        endpoint never sees the fieldset reference.
+
+        Parameters
+        ----------
+        fieldset: str or dict
+            Either a fieldset name (str) or a pre-fetched fieldset dict
+            returned by Fieldset.get_fieldset. If a name is given without
+            `group`, the fieldset-group tree is walked to find a unique
+            match.
+        group: str, optional
+            Fieldset-group ID. Skips the tree walk when `fieldset` is a name.
+        aggregate: str, optional
+            Aggregation function applied to every field. Default 'none'.
+            Same allowlist as select().
+
+        Examples
+        --------
+        >>> query.select_fieldset("Standard Flight Metrics")
+        >>> query.select_fieldset("Standard Flight Metrics", group="<group-id>")
+        >>> fs = Fieldset(conn, ems_id).get_fieldset("<group-id>", "Standard Flight Metrics")
+        >>> query.select_fieldset(fs)
+        """
+        aggs = ['none', 'avg', 'count', 'max', 'min', 'stdev', 'sum', 'var']
+        if aggregate not in aggs:
+            sys.exit("Wrong aggregation selected. Use one of %s." % aggs)
+
+        fs = self._resolve_fieldset_arg(fieldset, group)
+        fields_df = fs['fields']
+
+        if len(fields_df) == 0:
+            print("-- Warning: fieldset '%s' contains no fields; nothing added."
+                  % fs.get('name', '<unknown>'))
+            return
+
+        added = 0
+        for _, row in fields_df.iterrows():
+            field_id = row.get('id')
+            if not field_id or (isinstance(field_id, float) and pd.isna(field_id)):
+                print("-- Skipping field '%s' in fieldset '%s': missing field ID."
+                      % (row.get('name'), fs.get('name', '<unknown>')))
+                continue
+            self.__queryset['select'].append({
+                'fieldId': field_id,
+                'aggregate': aggregate,
+            })
+            self.__columns.append({
+                'id': field_id,
+                'name': row.get('name') or field_id,
+                'type': row.get('type'),
+            })
+            added += 1
+
+        print("-- Added %d field%s from fieldset '%s'."
+              % (added, 's' if added != 1 else '', fs.get('name', '<unknown>')))
+
+    def _resolve_fieldset_arg(self, fieldset, group):
+        # Pre-fetched fieldset dict.
+        if isinstance(fieldset, dict) and isinstance(fieldset.get('fields'), pd.DataFrame):
+            return fieldset
+
+        if not isinstance(fieldset, string_types):
+            raise TypeError(
+                "fieldset must be a fieldset name (str) or a fieldset dict "
+                "returned by Fieldset.get_fieldset()."
+            )
+
+        if group is not None:
+            return self.__fieldset.get_fieldset(group, fieldset)
+
+        # No group supplied: walk the tree for a unique match.
+        hits = self.__fieldset.find(fieldset)
+        if len(hits) == 0:
+            raise ValueError(
+                "Fieldset '%s' not found in any visible fieldset group. "
+                "List groups with Fieldset.get_groups() and contents with "
+                "Fieldset.get_group(group_id)." % fieldset
+            )
+        if len(hits) > 1:
+            paths = [' > '.join(h['path']) for h in hits]
+            raise ValueError(
+                "Fieldset name '%s' is ambiguous - found in multiple groups:\n  %s\n"
+                "Pass `group` explicitly to disambiguate."
+                % (fieldset, '\n  '.join(paths))
+            )
+        return self.__fieldset.get_fieldset(hits[0]['group_id'], fieldset)
 
     def deselect(self, *args):
         """

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ def readme():
         return f.read()
 
 setup(name = 'emspy',
-      version = '0.6.9',
+      version = '0.7.0',
       description = 'A Python EMS RESTful API Client/Wrapper',
       long_description=readme(),
       long_description_content_type="text/markdown",

--- a/tests/mock_connection.py
+++ b/tests/mock_connection.py
@@ -525,6 +525,142 @@ class MockConnection(Connection):
                 }
 
 
+        elif uri_keys == ('fieldset', 'fieldset_groups'):
+            # Returns a bare list of groups (the parser tolerates either bare
+            # arrays or {'groups': [...]} envelopes).
+            content = [
+                {
+                    "id": "mock-group-id",
+                    "name": "Mock Group",
+                    "description": "Group used by the mocked test suite.",
+                },
+                {
+                    "id": "dup-group-a",
+                    "name": "Dup Group A",
+                    "description": None,
+                },
+                {
+                    "id": "dup-group-b",
+                    "name": "Dup Group B",
+                    "description": None,
+                },
+                {
+                    "id": "empty-group-id",
+                    "name": "Empty Group",
+                    "description": None,
+                },
+                {
+                    "id": "forbidden-group-id",
+                    "name": "Forbidden Group",
+                    "description": "Raises on get_group.",
+                },
+            ]
+        elif uri_keys == ('fieldset', 'fieldset_group'):
+            _ems_id, group_id = uri_args
+            if group_id == "mock-group-id":
+                content = {
+                    "groups": [
+                        {
+                            "id": "sub-group-id",
+                            "name": "Sub Group",
+                            "description": None,
+                        }
+                    ],
+                    "fieldSets": [
+                        {"id": "Mock Fieldset", "name": "Mock Fieldset",
+                         "description": "schemaItems shape."},
+                        {"id": "Alt Shape Fieldset", "name": "Alt Shape Fieldset",
+                         "description": "fields shape."},
+                    ],
+                }
+            elif group_id == "sub-group-id":
+                content = {
+                    "groups": [],
+                    "fieldSets": [
+                        {"id": "Deep Fieldset", "name": "Deep Fieldset",
+                         "description": "Lives one level down."},
+                    ],
+                }
+            elif group_id == "dup-group-a":
+                content = {
+                    "groups": [],
+                    "fieldSets": [
+                        {"id": "Dup Fieldset", "name": "Dup Fieldset",
+                         "description": "Appears in two groups."},
+                    ],
+                }
+            elif group_id == "dup-group-b":
+                content = {
+                    "groups": [],
+                    "fieldSets": [
+                        {"id": "Dup Fieldset", "name": "Dup Fieldset",
+                         "description": "Appears in two groups."},
+                    ],
+                }
+            elif group_id == "empty-group-id":
+                content = {"groups": [], "fieldSets": []}
+            elif group_id == "forbidden-group-id":
+                # Simulates a permission-gated subgroup; the tree-walk should
+                # catch this and skip silently.
+                raise HTTPError(
+                    "http://mock/forbidden", 403, "Forbidden", {}, None
+                )
+            else:
+                content = {"groups": [], "fieldSets": []}
+        elif uri_keys == ('fieldset', 'fieldset'):
+            _ems_id, group_id, fieldset_name = uri_args
+            if fieldset_name == "Mock Fieldset":
+                # schemaItems shape (moniker / description / type)
+                content = {
+                    "name": "Mock Fieldset",
+                    "schemaItems": [
+                        {"moniker": "field-id-1",
+                         "description": "Takeoff Airport Code",
+                         "type": "string"},
+                        {"moniker": "field-id-2",
+                         "description": "Landing Airport Code",
+                         "type": "string"},
+                        {"moniker": "field-id-3",
+                         "description": "Flight Date",
+                         "type": "dateTime"},
+                    ],
+                }
+            elif fieldset_name == "Alt Shape Fieldset":
+                # Older 'fields' shape with id/name/dataType
+                content = {
+                    "name": "Alt Shape Fieldset",
+                    "fields": [
+                        {"id": "alt-field-1", "name": "Alt One",
+                         "dataType": "number"},
+                        {"id": "alt-field-2", "name": "Alt Two",
+                         "dataType": "boolean"},
+                    ],
+                }
+            elif fieldset_name == "Deep Fieldset":
+                content = {
+                    "name": "Deep Fieldset",
+                    "schemaItems": [
+                        {"moniker": "deep-field-1",
+                         "description": "Deep One",
+                         "type": "number"},
+                    ],
+                }
+            elif fieldset_name == "Dup Fieldset":
+                content = {
+                    "name": "Dup Fieldset",
+                    "schemaItems": [
+                        {"moniker": "dup-field-1",
+                         "description": "Dup One",
+                         "type": "number"},
+                    ],
+                }
+            elif fieldset_name == "Empty Fieldset":
+                content = {"name": "Empty Fieldset", "schemaItems": []}
+            else:
+                raise HTTPError(
+                    "http://mock/fieldset", 404, "Not Found", {}, None
+                )
+
         return RESPONSE_HEADERS, content
 
 

--- a/tests/mock_connection.py
+++ b/tests/mock_connection.py
@@ -554,6 +554,11 @@ class MockConnection(Connection):
                     "name": "Forbidden Group",
                     "description": "Raises on get_group.",
                 },
+                {
+                    "id": "real-ids-group-id",
+                    "name": "Real IDs Group",
+                    "description": "Fieldsets with entity-type-shaped field IDs.",
+                },
             ]
         elif uri_keys == ('fieldset', 'fieldset_group'):
             _ems_id, group_id = uri_args
@@ -605,6 +610,18 @@ class MockConnection(Connection):
                 raise HTTPError(
                     "http://mock/forbidden", 403, "Forbidden", {}, None
                 )
+            elif group_id == "real-ids-group-id":
+                content = {
+                    "groups": [],
+                    "fieldSets": [
+                        {"id": "Flights Fieldset", "name": "Flights Fieldset",
+                         "description": "All foqa-flights."},
+                        {"id": "Aircraft Fieldset", "name": "Aircraft Fieldset",
+                         "description": "All aircraft."},
+                        {"id": "Mixed DB Fieldset", "name": "Mixed DB Fieldset",
+                         "description": "Mixes flights and aircraft."},
+                    ],
+                }
             else:
                 content = {"groups": [], "fieldSets": []}
         elif uri_keys == ('fieldset', 'fieldset'):
@@ -656,6 +673,39 @@ class MockConnection(Connection):
                 }
             elif fieldset_name == "Empty Fieldset":
                 content = {"name": "Empty Fieldset", "schemaItems": []}
+            elif fieldset_name == "Flights Fieldset":
+                content = {
+                    "name": "Flights Fieldset",
+                    "schemaItems": [
+                        {"moniker": "[-hub-][field][[[ems-core][entity-type][foqa-flights]][[ems-core][base-field][flight.exact-date]]]",
+                         "description": "Flight Date",
+                         "type": "dateTime"},
+                        {"moniker": "[-hub-][field][[[ems-core][entity-type][foqa-flights]][[ems-core][base-field][flight.exist-takeoff]]]",
+                         "description": "Takeoff Valid",
+                         "type": "boolean"},
+                    ],
+                }
+            elif fieldset_name == "Aircraft Fieldset":
+                content = {
+                    "name": "Aircraft Fieldset",
+                    "schemaItems": [
+                        {"moniker": "[-hub-][field][[[ems-aux][entity-type][aircraft]][[ems-aux][base-field][aircraft.serial-number]]]",
+                         "description": "Serial Number",
+                         "type": "string"},
+                    ],
+                }
+            elif fieldset_name == "Mixed DB Fieldset":
+                content = {
+                    "name": "Mixed DB Fieldset",
+                    "schemaItems": [
+                        {"moniker": "[-hub-][field][[[ems-core][entity-type][foqa-flights]][[ems-core][base-field][flight.exact-date]]]",
+                         "description": "Flight Date",
+                         "type": "dateTime"},
+                        {"moniker": "[-hub-][field][[[ems-aux][entity-type][aircraft]][[ems-aux][base-field][aircraft.serial-number]]]",
+                         "description": "Serial Number",
+                         "type": "string"},
+                    ],
+                }
             else:
                 raise HTTPError(
                     "http://mock/fieldset", 404, "Not Found", {}, None

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -401,3 +401,62 @@ def test_select_fieldset_skips_verification_for_unshaped_ids(
         'Mock Fieldset', group='mock-group-id'
     )
     assert len(fltquery_with_flights_db._FltQuery__queryset['select']) == 3
+
+
+# deselect against fieldset-added fields ------------------------------------
+
+def test_deselect_fieldset_field_by_name(fltquery):
+    fltquery.select_fieldset('Mock Fieldset', group='mock-group-id')
+    assert len(fltquery._FltQuery__queryset['select']) == 3
+
+    fltquery.deselect('Landing Airport Code')
+
+    qs = fltquery._FltQuery__queryset
+    cols = fltquery._FltQuery__columns
+    assert len(qs['select']) == 2
+    assert 'field-id-2' not in {e['fieldId'] for e in qs['select']}
+    assert 'field-id-2' not in {c['id'] for c in cols}
+    assert {c['id'] for c in cols} == {'field-id-1', 'field-id-3'}
+
+
+def test_deselect_fieldset_field_by_name_is_case_insensitive(fltquery):
+    fltquery.select_fieldset('Mock Fieldset', group='mock-group-id')
+    fltquery.deselect('landing airport')
+    qs = fltquery._FltQuery__queryset
+    assert len(qs['select']) == 2
+    assert 'field-id-2' not in {e['fieldId'] for e in qs['select']}
+
+
+def test_deselect_fieldset_field_by_exact_id(fltquery):
+    fltquery.select_fieldset('Mock Fieldset', group='mock-group-id')
+    fltquery.deselect('field-id-2')
+    qs = fltquery._FltQuery__queryset
+    cols = fltquery._FltQuery__columns
+    assert len(qs['select']) == 2
+    assert {c['id'] for c in cols} == {'field-id-1', 'field-id-3'}
+
+
+def test_deselect_unknown_field_raises_with_selection_listed(fltquery):
+    fltquery.select_fieldset('Mock Fieldset', group='mock-group-id')
+    with pytest.raises(ValueError) as exc:
+        fltquery.deselect('does-not-exist')
+    msg = str(exc.value)
+    assert 'no matching field' in msg
+    # The error should name what's actually selected so the user can correct
+    # the call without printing the queryset themselves.
+    assert 'Takeoff Airport Code' in msg
+    assert 'field-id-1' in msg
+    # Nothing was removed.
+    assert len(fltquery._FltQuery__queryset['select']) == 3
+
+
+def test_deselect_removes_only_matching_field(fltquery):
+    fltquery.select_fieldset('Mock Fieldset', group='mock-group-id')
+    fltquery.deselect('field-id-1')
+    fltquery.deselect('field-id-3')
+    qs = fltquery._FltQuery__queryset
+    cols = fltquery._FltQuery__columns
+    assert len(qs['select']) == 1
+    assert qs['select'][0]['fieldId'] == 'field-id-2'
+    assert len(cols) == 1
+    assert cols[0]['id'] == 'field-id-2'

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -153,6 +153,17 @@ def test_find_unambiguous_match(fieldset):
     hits = fieldset.find('Mock Fieldset')
     assert len(hits) == 1
     assert hits[0]['group_id'] == 'mock-group-id'
+    assert hits[0]['name'] == 'Mock Fieldset'
+    assert hits[0]['path'] == ['Mock Group']
+
+
+def test_find_is_case_insensitive(fieldset):
+    hits = fieldset.find('mock fieldset')
+    assert len(hits) == 1
+    assert hits[0]['group_id'] == 'mock-group-id'
+    # Canonical casing is preserved in the hit so downstream get_fieldset()
+    # calls hit the API with the case the server expects.
+    assert hits[0]['name'] == 'Mock Fieldset'
     assert hits[0]['path'] == ['Mock Group']
 
 
@@ -250,6 +261,15 @@ def test_select_fieldset_by_name_walks_tree(fltquery):
     }
 
 
+def test_select_fieldset_by_name_is_case_insensitive(fltquery):
+    fltquery.select_fieldset('mock fieldset')
+    queryset = fltquery._FltQuery__queryset
+    assert len(queryset['select']) == 3
+    assert {e['fieldId'] for e in queryset['select']} == {
+        'field-id-1', 'field-id-2', 'field-id-3'
+    }
+
+
 def test_select_fieldset_ambiguous_name_raises(fltquery):
     with pytest.raises(ValueError) as exc:
         fltquery.select_fieldset('Dup Fieldset')
@@ -276,13 +296,6 @@ def test_select_fieldset_with_prefetched_dict(fltquery):
     assert queryset['select'][0]['fieldId'] == 'alt-field-1'
 
 
-def test_select_fieldset_with_aggregate(fltquery):
-    fltquery.select_fieldset('Mock Fieldset', group='mock-group-id',
-                              aggregate='avg')
-    for entry in fltquery._FltQuery__queryset['select']:
-        assert entry['aggregate'] == 'avg'
-
-
 def test_select_fieldset_stacks_with_regular_select(fltquery):
     # Verifies fieldset entries coexist with select() entries in one queryset.
     # Stub a fake select() entry directly rather than going through fieldtree
@@ -305,12 +318,6 @@ def test_select_fieldset_stacks_with_regular_select(fltquery):
 def test_select_fieldset_rejects_bad_type(fltquery):
     with pytest.raises(TypeError):
         fltquery.select_fieldset(12345)
-
-
-def test_select_fieldset_rejects_unknown_aggregate(fltquery):
-    with pytest.raises(SystemExit):
-        fltquery.select_fieldset('Mock Fieldset', group='mock-group-id',
-                                  aggregate='median')
 
 
 def test_select_fieldset_empty_fieldset_is_noop(fltquery):

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -1,0 +1,309 @@
+import os
+import pytest
+import pandas as pd
+
+import emspy
+from emspy.query import Fieldset
+from emspy.query.fieldset import _parse_fieldset_fields
+from mock_connection import MockConnection
+from mock_ems import MockEMS
+from mock_query import MockFltQuery
+
+
+# Fixtures -------------------------------------------------------------------
+
+@pytest.fixture
+def mocks(monkeypatch):
+    monkeypatch.setattr(emspy.query.query, 'EMS', MockEMS)
+    monkeypatch.setattr(emspy, 'Connection', MockConnection)
+
+
+@pytest.fixture
+def fieldset(mocks):
+    ems_id = 1
+    connection = MockConnection(user='', pwd='')
+    return Fieldset(connection, ems_id)
+
+
+@pytest.fixture
+def fltquery(mocks, tmp_path):
+    # MockFltQuery wires Fieldset into FltQuery via _init_assets and uses the
+    # bundled mock_metadata.db for the unused fieldtree.
+    test_path = os.path.dirname(os.path.realpath(__file__))
+    db_path = os.path.join(test_path, 'mock_metadata.db')
+    return MockFltQuery(MockConnection(user='', pwd=''), 'ems-mock',
+                         data_file=db_path)
+
+
+# get_groups -----------------------------------------------------------------
+
+def test_get_groups_returns_dataframe(fieldset):
+    df = fieldset.get_groups()
+    assert isinstance(df, pd.DataFrame)
+    assert list(df.columns) == ['id', 'name', 'description']
+    assert 'mock-group-id' in df['id'].tolist()
+    assert 'Mock Group' in df['name'].tolist()
+
+
+def test_get_groups_uses_cache_on_second_call(fieldset, monkeypatch):
+    fieldset.get_groups()  # priming call
+    call_count = {'n': 0}
+    real_request = fieldset._conn.request
+
+    def counting_request(*args, **kwargs):
+        call_count['n'] += 1
+        return real_request(*args, **kwargs)
+
+    monkeypatch.setattr(fieldset._conn, 'request', counting_request)
+    fieldset.get_groups()
+    assert call_count['n'] == 0
+
+
+def test_get_groups_refresh_bypasses_cache(fieldset, monkeypatch):
+    fieldset.get_groups()  # priming call
+    call_count = {'n': 0}
+    real_request = fieldset._conn.request
+
+    def counting_request(*args, **kwargs):
+        call_count['n'] += 1
+        return real_request(*args, **kwargs)
+
+    monkeypatch.setattr(fieldset._conn, 'request', counting_request)
+    fieldset.get_groups(refresh=True)
+    assert call_count['n'] == 1
+
+
+# get_group ------------------------------------------------------------------
+
+def test_get_group_splits_subgroups_and_fieldsets(fieldset):
+    df = fieldset.get_group('mock-group-id')
+    assert list(df.columns) == ['type', 'id', 'name', 'description']
+    groups = df[df['type'] == 'group']
+    fieldsets = df[df['type'] == 'fieldset']
+    assert len(groups) == 1
+    assert groups.iloc[0]['name'] == 'Sub Group'
+    assert len(fieldsets) == 2
+    assert set(fieldsets['name'].tolist()) == {'Mock Fieldset', 'Alt Shape Fieldset'}
+
+
+def test_get_group_empty(fieldset):
+    df = fieldset.get_group('empty-group-id')
+    assert len(df) == 0
+    assert list(df.columns) == ['type', 'id', 'name', 'description']
+
+
+def test_get_group_validates_group_id(fieldset):
+    with pytest.raises(ValueError):
+        fieldset.get_group('')
+    with pytest.raises(ValueError):
+        fieldset.get_group(None)
+
+
+# get_fieldset ---------------------------------------------------------------
+
+def test_get_fieldset_schemaitems_shape(fieldset):
+    fs = fieldset.get_fieldset('mock-group-id', 'Mock Fieldset')
+    assert fs['name'] == 'Mock Fieldset'
+    assert fs['group_id'] == 'mock-group-id'
+    assert fs['ems_id'] == 1
+    df = fs['fields']
+    assert list(df.columns) == ['id', 'name', 'type']
+    assert df.iloc[0]['id'] == 'field-id-1'
+    assert df.iloc[0]['name'] == 'Takeoff Airport Code'
+    assert df.iloc[0]['type'] == 'string'
+    assert len(df) == 3
+
+
+def test_get_fieldset_alt_fields_shape(fieldset):
+    # Older response shape using 'fields' + id/name/dataType
+    fs = fieldset.get_fieldset('mock-group-id', 'Alt Shape Fieldset')
+    df = fs['fields']
+    assert df.iloc[0]['id'] == 'alt-field-1'
+    assert df.iloc[0]['name'] == 'Alt One'
+    assert df.iloc[0]['type'] == 'number'
+    assert len(df) == 2
+
+
+def test_get_fieldset_cache(fieldset, monkeypatch):
+    fieldset.get_fieldset('mock-group-id', 'Mock Fieldset')
+    call_count = {'n': 0}
+    real_request = fieldset._conn.request
+
+    def counting_request(*args, **kwargs):
+        call_count['n'] += 1
+        return real_request(*args, **kwargs)
+
+    monkeypatch.setattr(fieldset._conn, 'request', counting_request)
+    fieldset.get_fieldset('mock-group-id', 'Mock Fieldset')
+    assert call_count['n'] == 0
+
+
+# find -----------------------------------------------------------------------
+
+def test_find_unambiguous_match(fieldset):
+    hits = fieldset.find('Mock Fieldset')
+    assert len(hits) == 1
+    assert hits[0]['group_id'] == 'mock-group-id'
+    assert hits[0]['path'] == ['Mock Group']
+
+
+def test_find_walks_into_subgroups(fieldset):
+    hits = fieldset.find('Deep Fieldset')
+    assert len(hits) == 1
+    assert hits[0]['group_id'] == 'sub-group-id'
+    assert hits[0]['path'] == ['Mock Group', 'Sub Group']
+
+
+def test_find_returns_multiple_for_ambiguous_name(fieldset):
+    hits = fieldset.find('Dup Fieldset')
+    assert len(hits) == 2
+    group_ids = sorted(h['group_id'] for h in hits)
+    assert group_ids == ['dup-group-a', 'dup-group-b']
+
+
+def test_find_skips_permission_gated_subgroups(fieldset, capsys):
+    # 'Forbidden Group' raises HTTPError on get_group; the walk should
+    # swallow it, print a friendly note, and continue.
+    hits = fieldset.find('Mock Fieldset')
+    assert len(hits) == 1
+    captured = capsys.readouterr()
+    assert 'Skipping fieldset group' in captured.out
+    assert 'Forbidden Group' in captured.out
+    assert 'HTTP 403' in captured.out
+    assert 'Continuing search' in captured.out
+
+
+def test_find_returns_empty_when_not_found(fieldset):
+    assert fieldset.find('Nonexistent Fieldset') == []
+
+
+# clear_cache ----------------------------------------------------------------
+
+def test_clear_cache_empties_all_three(fieldset):
+    fieldset.get_groups()
+    fieldset.get_group('mock-group-id')
+    fieldset.get_fieldset('mock-group-id', 'Mock Fieldset')
+    assert fieldset._root_cache is not None
+    assert 'mock-group-id' in fieldset._group_cache
+    assert ('mock-group-id', 'Mock Fieldset') in fieldset._fieldset_cache
+
+    fieldset.clear_cache()
+    assert fieldset._root_cache is None
+    assert fieldset._group_cache == {}
+    assert fieldset._fieldset_cache == {}
+
+
+# Parser-level robustness ----------------------------------------------------
+
+def test_parse_fields_handles_bare_strings():
+    df = _parse_fieldset_fields(['just-an-id', 'another-id'])
+    assert list(df.columns) == ['id', 'name', 'type']
+    assert df.iloc[0]['id'] == 'just-an-id'
+    assert df.iloc[0]['name'] is None
+
+
+def test_parse_fields_handles_snake_case():
+    df = _parse_fieldset_fields([{'moniker': 'x', 'description': 'X',
+                                   'data_type': 'number'}])
+    assert df.iloc[0]['type'] == 'number'
+
+
+def test_parse_fields_empty():
+    df = _parse_fieldset_fields([])
+    assert list(df.columns) == ['id', 'name', 'type']
+    assert len(df) == 0
+
+
+# FltQuery.select_fieldset integration --------------------------------------
+
+def test_select_fieldset_with_explicit_group(fltquery):
+    fltquery.select_fieldset('Mock Fieldset', group='mock-group-id')
+    queryset = fltquery._FltQuery__queryset
+    columns = fltquery._FltQuery__columns
+
+    assert len(queryset['select']) == 3
+    assert queryset['select'][0] == {
+        'fieldId': 'field-id-1',
+        'aggregate': 'none',
+    }
+    assert len(columns) == 3
+    assert columns[0]['id'] == 'field-id-1'
+    assert columns[0]['name'] == 'Takeoff Airport Code'
+    assert columns[0]['type'] == 'string'
+
+
+def test_select_fieldset_by_name_walks_tree(fltquery):
+    fltquery.select_fieldset('Mock Fieldset')
+    queryset = fltquery._FltQuery__queryset
+    assert len(queryset['select']) == 3
+    assert {e['fieldId'] for e in queryset['select']} == {
+        'field-id-1', 'field-id-2', 'field-id-3'
+    }
+
+
+def test_select_fieldset_ambiguous_name_raises(fltquery):
+    with pytest.raises(ValueError) as exc:
+        fltquery.select_fieldset('Dup Fieldset')
+    msg = str(exc.value)
+    assert 'ambiguous' in msg
+    assert 'Dup Group A' in msg
+    assert 'Dup Group B' in msg
+
+
+def test_select_fieldset_not_found_raises(fltquery):
+    with pytest.raises(ValueError) as exc:
+        fltquery.select_fieldset('Nonexistent Fieldset')
+    assert 'not found' in str(exc.value)
+
+
+def test_select_fieldset_with_prefetched_dict(fltquery):
+    # Pre-fetch via Fieldset, then pass the dict to select_fieldset.
+    fs = Fieldset(fltquery._conn, fltquery._ems_id).get_fieldset(
+        'mock-group-id', 'Alt Shape Fieldset'
+    )
+    fltquery.select_fieldset(fs)
+    queryset = fltquery._FltQuery__queryset
+    assert len(queryset['select']) == 2
+    assert queryset['select'][0]['fieldId'] == 'alt-field-1'
+
+
+def test_select_fieldset_with_aggregate(fltquery):
+    fltquery.select_fieldset('Mock Fieldset', group='mock-group-id',
+                              aggregate='avg')
+    for entry in fltquery._FltQuery__queryset['select']:
+        assert entry['aggregate'] == 'avg'
+
+
+def test_select_fieldset_stacks_with_regular_select(fltquery):
+    # Verifies fieldset entries coexist with select() entries in one queryset.
+    # Stub a fake select() entry directly rather than going through fieldtree
+    # discovery, which is unrelated to what we're testing.
+    fltquery._FltQuery__queryset['select'].append({
+        'fieldId': 'pre-existing-field',
+        'aggregate': 'none',
+    })
+    fltquery._FltQuery__columns.append({
+        'id': 'pre-existing-field', 'name': 'Pre-existing', 'type': 'string'
+    })
+    pre_len = len(fltquery._FltQuery__queryset['select'])
+    fltquery.select_fieldset('Mock Fieldset', group='mock-group-id')
+    post_len = len(fltquery._FltQuery__queryset['select'])
+    assert post_len == pre_len + 3
+    # Both kinds of entries are flat {fieldId, aggregate} dicts.
+    assert fltquery._FltQuery__queryset['select'][0]['fieldId'] == 'pre-existing-field'
+
+
+def test_select_fieldset_rejects_bad_type(fltquery):
+    with pytest.raises(TypeError):
+        fltquery.select_fieldset(12345)
+
+
+def test_select_fieldset_rejects_unknown_aggregate(fltquery):
+    with pytest.raises(SystemExit):
+        fltquery.select_fieldset('Mock Fieldset', group='mock-group-id',
+                                  aggregate='median')
+
+
+def test_select_fieldset_empty_fieldset_is_noop(fltquery):
+    fltquery.select_fieldset('Empty Fieldset', group='mock-group-id')
+    assert len(fltquery._FltQuery__queryset['select']) == 0

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -460,3 +460,59 @@ def test_deselect_removes_only_matching_field(fltquery):
     assert qs['select'][0]['fieldId'] == 'field-id-2'
     assert len(cols) == 1
     assert cols[0]['id'] == 'field-id-2'
+
+
+def test_deselect_ambiguous_substring_removes_shortest_by_default(fltquery):
+    # 'Mock Fieldset' has 'Takeoff Airport Code' and 'Landing Airport Code';
+    # the substring 'airport' matches both. The default (legacy) behaviour
+    # is to remove only the shortest-named match (tie -> first encountered).
+    fltquery.select_fieldset('Mock Fieldset', group='mock-group-id')
+    fltquery.deselect('airport')
+
+    qs = fltquery._FltQuery__queryset
+    # Two airport fields and one date field were selected; one airport is
+    # removed by the default single-match behaviour.
+    assert len(qs['select']) == 2
+    remaining_ids = {e['fieldId'] for e in qs['select']}
+    # field-id-3 (Flight Date) must still be present; exactly one of
+    # field-id-1 / field-id-2 must remain.
+    assert 'field-id-3' in remaining_ids
+    assert len(remaining_ids & {'field-id-1', 'field-id-2'}) == 1
+
+
+def test_deselect_all_matches_removes_every_substring_hit(fltquery):
+    fltquery.select_fieldset('Mock Fieldset', group='mock-group-id')
+    fltquery.deselect('airport', all_matches=True)
+
+    qs = fltquery._FltQuery__queryset
+    remaining_ids = {e['fieldId'] for e in qs['select']}
+    # Both airport fields removed, only the date field remains.
+    assert remaining_ids == {'field-id-3'}
+
+
+def test_deselect_rejects_unknown_kwarg(fltquery):
+    fltquery.select_fieldset('Mock Fieldset', group='mock-group-id')
+    with pytest.raises(TypeError):
+        fltquery.deselect('field-id-1', bogus=True)
+
+
+def test_deselect_prints_removed_field(fltquery, capsys):
+    fltquery.select_fieldset('Mock Fieldset', group='mock-group-id')
+    capsys.readouterr()  # drain the select_fieldset print
+
+    fltquery.deselect('field-id-2')
+    out = capsys.readouterr().out
+    assert 'Deselected' in out
+    assert 'field-id-2' in out
+    assert 'Landing Airport Code' in out
+
+
+def test_deselect_prints_multi_removal_summary(fltquery, capsys):
+    fltquery.select_fieldset('Mock Fieldset', group='mock-group-id')
+    capsys.readouterr()
+
+    fltquery.deselect('airport', all_matches=True)
+    out = capsys.readouterr().out
+    assert 'Deselected 2 fields' in out
+    assert 'Takeoff Airport Code' in out
+    assert 'Landing Airport Code' in out

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -5,6 +5,7 @@ import pandas as pd
 import emspy
 from emspy.query import Fieldset
 from emspy.query.fieldset import _parse_fieldset_fields
+from emspy.query.fltquery import _extract_field_entity_type
 from mock_connection import MockConnection
 from mock_ems import MockEMS
 from mock_query import MockFltQuery
@@ -33,6 +34,14 @@ def fltquery(mocks, tmp_path):
     db_path = os.path.join(test_path, 'mock_metadata.db')
     return MockFltQuery(MockConnection(user='', pwd=''), 'ems-mock',
                          data_file=db_path)
+
+
+@pytest.fixture
+def fltquery_with_flights_db(fltquery):
+    # FltQuery pointed at the FDW Flights database so the entity-type guard
+    # in select_fieldset can compare against a real database ID.
+    fltquery.set_database('FDW Flights')
+    return fltquery
 
 
 # get_groups -----------------------------------------------------------------
@@ -307,3 +316,81 @@ def test_select_fieldset_rejects_unknown_aggregate(fltquery):
 def test_select_fieldset_empty_fieldset_is_noop(fltquery):
     fltquery.select_fieldset('Empty Fieldset', group='mock-group-id')
     assert len(fltquery._FltQuery__queryset['select']) == 0
+
+
+# Entity-type extraction -----------------------------------------------------
+
+def test_extract_field_entity_type_recognises_shaped_id():
+    fid = ("[-hub-][field][[[ems-core][entity-type][foqa-flights]]"
+           "[[ems-core][base-field][flight.exact-date]]]")
+    assert _extract_field_entity_type(fid) == "[ems-core][entity-type][foqa-flights]"
+
+
+def test_extract_field_entity_type_handles_dimension_token():
+    fid = ("[-hub-][field][[[ems-core][entity-type]"
+           "[dimension:096709fb2fb743b1bb3b6bbbf7160c8b]]"
+           "[[ems-core][base-field][example]]]")
+    assert _extract_field_entity_type(fid) == (
+        "[ems-core][entity-type][dimension:096709fb2fb743b1bb3b6bbbf7160c8b]"
+    )
+
+
+def test_extract_field_entity_type_returns_none_for_bare_id():
+    assert _extract_field_entity_type("field-id-1") is None
+
+
+def test_extract_field_entity_type_returns_none_for_non_string():
+    assert _extract_field_entity_type(None) is None
+    assert _extract_field_entity_type(12345) is None
+
+
+# Database verification guard -----------------------------------------------
+
+def test_select_fieldset_skips_verification_when_no_database_set(fltquery):
+    # The 'fltquery' fixture never calls set_database. The guard must skip
+    # silently rather than blowing up when there's nothing to compare to.
+    fltquery.select_fieldset('Flights Fieldset', group='real-ids-group-id')
+    assert len(fltquery._FltQuery__queryset['select']) == 2
+
+
+def test_select_fieldset_passes_verification_when_database_matches(
+        fltquery_with_flights_db):
+    fltquery_with_flights_db.select_fieldset(
+        'Flights Fieldset', group='real-ids-group-id'
+    )
+    assert len(fltquery_with_flights_db._FltQuery__queryset['select']) == 2
+
+
+def test_select_fieldset_rejects_mismatched_database(fltquery_with_flights_db):
+    with pytest.raises(ValueError) as exc:
+        fltquery_with_flights_db.select_fieldset(
+            'Aircraft Fieldset', group='real-ids-group-id'
+        )
+    msg = str(exc.value)
+    assert "different database" in msg
+    assert "foqa-flights" in msg
+    assert "aircraft" in msg
+    # Nothing was added.
+    assert len(fltquery_with_flights_db._FltQuery__queryset['select']) == 0
+
+
+def test_select_fieldset_rejects_mixed_databases(fltquery_with_flights_db):
+    with pytest.raises(ValueError) as exc:
+        fltquery_with_flights_db.select_fieldset(
+            'Mixed DB Fieldset', group='real-ids-group-id'
+        )
+    msg = str(exc.value)
+    assert "multiple databases" in msg
+    assert "foqa-flights" in msg
+    assert "aircraft" in msg
+    assert len(fltquery_with_flights_db._FltQuery__queryset['select']) == 0
+
+
+def test_select_fieldset_skips_verification_for_unshaped_ids(
+        fltquery_with_flights_db):
+    # 'Mock Fieldset' uses bare 'field-id-N' IDs with no extractable entity
+    # type. The guard must skip silently and let the select proceed.
+    fltquery_with_flights_db.select_fieldset(
+        'Mock Fieldset', group='mock-group-id'
+    )
+    assert len(fltquery_with_flights_db._FltQuery__queryset['select']) == 3

--- a/tests/test_select_id.py
+++ b/tests/test_select_id.py
@@ -119,7 +119,12 @@ def test_deselect_after_select_id_cached():
 
 
 def test_deselect_after_select_id_api():
-    """deselect removes a field added via select_id's API fallback path."""
+    """deselect removes a field added via select_id's API fallback path.
+
+    The fieldtree is left empty - deselect must match against the current
+    selection directly (by name in this case), without consulting the
+    fieldtree.
+    """
     connection = MockConnection(user='', pwd='')
     query = MockFltQuery(connection, 'ems24-app',
                          data_file=os.path.join(test_path, 'mock_metadata.db'))
@@ -130,11 +135,18 @@ def test_deselect_after_select_id_api():
     qs = query.in_dict()
     assert len(qs['select']) == 1
 
-    # Now populate the fieldtree so deselect can find the field by name
-    query.update_fieldtree(
-        'Flight Information',
-        exclude_tree=['Processing', 'Date Times', 'FlightPulse']
-    )
     query.deselect('Flight Record')
+    qs = query.in_dict()
+    assert len(qs['select']) == 0
+
+
+def test_deselect_by_exact_field_id():
+    """deselect accepts the exact field id, no name lookup needed."""
+    connection = MockConnection(user='', pwd='')
+    query = MockFltQuery(connection, 'ems24-app',
+                         data_file=os.path.join(test_path, 'mock_metadata.db'))
+    query.set_database('FDW Flights')
+    query.select_id(FLIGHT_RECORD_ID)
+    query.deselect(FLIGHT_RECORD_ID)
     qs = query.in_dict()
     assert len(qs['select']) == 0


### PR DESCRIPTION
## Summary

Wraps the EMS `/fieldset-groups` endpoint family in Python so users can apply a server-curated bundle of fields to a `FltQuery` in one call, without walking the field tree. Also bundles in two related additions and a number of compat / bug fixes — see `NEWS.md` for the full 0.7.0 changelog.

- New `Fieldset(conn, ems_id)` class (parallels `AnalyticSet`) with `get_groups()`, `get_group(group_id)`, `get_fieldset(group_id, name)`, `find(name)`, `clear_cache()`. Results cached in-memory per session; getters return copies so callers can't mutate the cache.
- New `FltQuery.select_fieldset(fieldset, group=None)` accepts either a pre-fetched fieldset or just a name. Without a `group`, it walks the fieldset-group tree to find a unique match; ambiguous names raise with the candidate paths. Verifies the fieldset's embedded `[ems-...][entity-type][...]` token matches the query's selected database.
- New `FltQuery.select_id(*field_ids, aggregate='none')` selects fields by their id (moniker) directly, bypassing name-based metadata tree search. Backed by a new `Flight.resolve_id()` that checks the local fieldtree cache first and falls back to the EMS field API (each un-cached id is one API call — prime the fieldtree first for bulk operations).
- Fields are expanded **client-side** into individual `{fieldId, aggregate}` entries — the `/query` endpoint never sees the fieldset reference. Field type metadata flows through to `__to_dataframe()` so column casting still works.
- Tolerant response parser handles the shape variations observed in the wild: `schemaItems` with `moniker`/`description` vs `fields` with `id`/`name`, bare-string field IDs, and bare-array vs `{groups: [...]}` group listings.
- Tree walk silently skips inaccessible subgroups but prints a clear `Skipping fieldset group '<name>': HTTP 403 ... Continuing search.` line so the underlying HTTP error output from the connection layer isn't mistaken for a failure.
- `FltQuery.deselect()` rewritten to match against the current selection directly (no fieldtree lookup), fixing a gap where fields added via `select_fieldset()` or `select_id()`'s API fallback path could not be removed. Default behaviour preserves the pre-0.7 `search_fields(unique=True)` semantics: ambiguous substring removes only the shortest-named match. Pass `all_matches=True` to remove every match in one call. Prints the field(s) it removed; raises `ValueError` listing the current selection on no match.

## Example

```python
from emspy import Connection
from emspy.query import FltQuery, Fieldset

conn = Connection(user, pwd, server_url="https://<host>/api")
query = FltQuery(conn)
query.set_database("FDW Flights")

# By name only (walks the tree for a unique match)
query.select_fieldset("Nautical Air Miles")

# By name + group (skips the tree walk)
query.select_fieldset("Nautical Air Miles", group="QFA Shared")

# Pre-fetched fieldset
fs = Fieldset(conn, query.get_ems_id()).get_fieldset("QFA Shared", "Nautical Air Miles")
print(fs['fields'])
query.select_fieldset(fs)
```

Mirrors the API surface of the equivalent feature in the R EMS client (Rems2).

## Test plan

- [x] 47 unit tests in `tests/test_fieldset.py` (mocked) covering: caching, refresh, tolerant parsing for both response shapes, `find()` with depth/permission-gated branches/ambiguous and missing names, `clear_cache()`, full `FltQuery.select_fieldset()` integration, the database entity-type guard, and the rewritten `deselect()` (by name, by id, case-insensitive, ambiguous default vs `all_matches=True`, no-match raises, print output).
- [x] 10 tests in `tests/test_select_id.py` covering cached / API-fallback paths and `deselect` after both.
- [x] Full suite green: `pytest tests/ --ignore=tests/test_db.py` -> 177 passed (the 2 errors in `tests/test_db.py` are pre-existing Windows-only SQLite file-lock issues unrelated to this PR; 183 tests collected total).
- [x] Verified live against a real EMS instance: pre-fetched fieldset path returns the expected 100x12 DataFrame; name-only resolution path returns the expected 5x12 DataFrame after the tree walk skips inaccessible groups with the friendly skip message.

## Files

- New: `emspy/query/fieldset.py`, `tests/test_fieldset.py`, `tests/test_select_id.py`, `NEWS.md`
- Modified: `emspy/common.py` (3 URIs), `emspy/query/__init__.py` (export), `emspy/query/fltquery.py` (wire-up + `select_fieldset()`, `select_id()`, rewritten `deselect()`), `emspy/query/flight.py` (`resolve_id`, `get_db_id`), `tests/mock_connection.py` (mock routes), `README.md` (Selecting a fieldset / select_id sections).