### PR TITLE
Fix Azure testing to remove Python versions no longer supported by Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,14 +8,14 @@ pool:
   vmImage: 'windows-latest'
 strategy:
   matrix:
-    Python27:
-      python.version: '2.7'
-    Python38:
-      python.version: '3.8'
-    Python39:
-      python.version: '3.9'
     Python310:
       python.version: '3.10'
+    Python311:
+      python.version: '3.11'
+    Python312:
+      python.version: '3.12'
+    Python313:
+      python.version: '3.13'
 
 steps:
 - task: UsePythonVersion@0


### PR DESCRIPTION
It was making me crazy watching these fail - this should fix the failures as Azure doesn't support the old Python versions any more.