### PR TITLE
Close sqlite3 connections in SQL injection tests

### DIFF
--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -275,9 +275,13 @@ def test_sql_injection_single_quote():
         );
         COMMIT;
     """
-    with sqlite3.connect('tmpDB.db') as conn:
+    conn = sqlite3.connect('tmpDB.db')
+    try:
         cursor = conn.cursor()
         cursor.executescript(sql)
+        cursor.close()
+    finally:
+        conn.close()
 
     # Import LocalData to test directly
     from emspy.query import LocalData
@@ -353,9 +357,13 @@ def test_sql_injection_delete():
         );
         COMMIT;
     """
-    with sqlite3.connect('tmpDB.db') as conn:
+    conn = sqlite3.connect('tmpDB.db')
+    try:
         cursor = conn.cursor()
         cursor.executescript(sql)
+        cursor.close()
+    finally:
+        conn.close()
 
     from emspy.query import LocalData
     ld = LocalData('tmpDB.db')


### PR DESCRIPTION
The `with sqlite3.connect(...) as conn:` block is a transaction context manager — it commits/rollbacks but does not close the connection. The leaked connection holds a file lock on Windows, causing teardown's `os.remove('tmpDB.db')` to fail with WinError 32.

Explicitly close the seeding connection so the autouse cleanup fixture can remove the temp DB on Windows CI.